### PR TITLE
optional ALB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| alb\_listener\_priority | Ordering of listeners, must be unique. | `number` | n/a | yes |
+| alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
+| alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
+| alb\_listener\_priority | The priority for the ALB listener rule between 1 and 50000. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. | `number` | `null` | no |
 | assign\_public\_ip | As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service. | `bool` | `false` | no |
 | cluster\_id | The ECS cluster id that should run this service | `string` | n/a | yes |
 | code\_build\_role\_name | Use an existing role for codebuild permissions that can be reused for multiple services. Otherwise a separate role for this service will be created. | `string` | `""` | no |
@@ -222,7 +224,7 @@ No requirements.
 | create\_log\_streaming | Creates a Kinesis Firehose delivery stream for streaming application logs to an existing Elasticsearch domain. | `bool` | `true` | no |
 | desired\_count | Desired count of services to be started/running. | `number` | `0` | no |
 | ecr | ECR repository configuration. | <pre>object({<br>    image_scanning_configuration = object({<br>      scan_on_push = bool<br>    })<br>    image_tag_mutability = string,<br>  })</pre> | <pre>{<br>  "image_scanning_configuration": {<br>    "scan_on_push": false<br>  },<br>  "image_tag_mutability": "MUTABLE"<br>}</pre> | no |
-| health\_check\_endpoint | Endpoint (/health) that will be probed by the LB to determine the service's health. | `string` | n/a | yes |
+| health\_check | A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults. | `map(string)` | `{}` | no |
 | logs\_domain\_name | The name of an existing Elasticsearch domain used as destination for the Firehose delivery stream. | `string` | `"application-logs"` | no |
 | logs\_firehose\_delivery\_stream\_s3\_backup\_bucket\_arn | Use an existing S3 bucket to backup log documents which couldn't be streamed to Elasticsearch. Otherwise a separate bucket for this service will be created. | `string` | `""` | no |
 | logs\_fluentbit\_cloudwatch\_log\_group\_name | Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ The following resources are referenced from this module and therefore prerequisi
 * Subnets — within this VPC, there must be at least one subnet tagged with `Tier = (public|private)`
 * SG (1) — within this VPC there must be a security group `Name = default`
 * SG (2) — within this VPC there must be a security group to allow traffic from ALB `Name = fargate-allow-alb-traffic`
-* DNS (VPC) — within this VPC there must be a private route53 zone with `name = vpc.internal.`
-* DNS (public) — currently there is a hard-coded route53 zone `name = buzz.t-online.delivery.`
+* IAM role — There should be a role named `ssm_ecs_task_execution_role` that will be used as a task execution role
+
+### Load Balancing
+
+A service will be attached to a `public` and/or `private` target groups per default. In addition Route53 records will be created for those target groups.Therefore the following resources need to be available:
+
 * ALB — there must be ALBs with `name = (public|private)`. 
 * ALB Listeners — Those ALBs should have listeners for HTTP(s) (Port `80` and `443`) configured
-* IAM role — There should be a role named `ssm_ecs_task_execution_role` that will be used as a task execution role
+* DNS (VPC) — within this VPC there must be a private route53 zone with `name = vpc.internal.`
+* DNS (public) — currently there is a hard-coded route53 zone `name = buzz.t-online.delivery.`
+
+
+In order to disable ALB target group attachments (e.g. for services in an App Mesh) set `alb_attach_public_target_group` and/or `alb_attach_private_target_group` to `false`.
 
 ### When using the automated deployment pipeline (optional):
 

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -16,11 +16,19 @@ The following resources are referenced from this module and therefore prerequisi
 * Subnets — within this VPC, there must be at least one subnet tagged with `Tier = (public|private)`
 * SG (1) — within this VPC there must be a security group `Name = default`
 * SG (2) — within this VPC there must be a security group to allow traffic from ALB `Name = fargate-allow-alb-traffic`
-* DNS (VPC) — within this VPC there must be a private route53 zone with `name = vpc.internal.`
-* DNS (public) — currently there is a hard-coded route53 zone `name = buzz.t-online.delivery.`
+* IAM role — There should be a role named `ssm_ecs_task_execution_role` that will be used as a task execution role
+
+### Load Balancing
+
+A service will be attached to a `public` and/or `private` target groups per default. In addition Route53 records will be created for those target groups.Therefore the following resources need to be available:
+
 * ALB — there must be ALBs with `name = (public|private)`. 
 * ALB Listeners — Those ALBs should have listeners for HTTP(s) (Port `80` and `443`) configured
-* IAM role — There should be a role named `ssm_ecs_task_execution_role` that will be used as a task execution role
+* DNS (VPC) — within this VPC there must be a private route53 zone with `name = vpc.internal.`
+* DNS (public) — currently there is a hard-coded route53 zone `name = buzz.t-online.delivery.`
+
+
+In order to disable ALB target group attachments (e.g. for services in an App Mesh) set `alb_attach_public_target_group` and/or `alb_attach_private_target_group` to `false`.
 
 ### When using the automated deployment pipeline (optional):
 

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -13,7 +13,9 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| alb\_listener\_priority | Ordering of listeners, must be unique. | `number` | n/a | yes |
+| alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
+| alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
+| alb\_listener\_priority | The priority for the ALB listener rule between 1 and 50000. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. | `number` | `null` | no |
 | assign\_public\_ip | As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service. | `bool` | `false` | no |
 | cluster\_id | The ECS cluster id that should run this service | `string` | n/a | yes |
 | code\_build\_role\_name | Use an existing role for codebuild permissions that can be reused for multiple services. Otherwise a separate role for this service will be created. | `string` | `""` | no |
@@ -27,7 +29,7 @@ No requirements.
 | create\_log\_streaming | Creates a Kinesis Firehose delivery stream for streaming application logs to an existing Elasticsearch domain. | `bool` | `true` | no |
 | desired\_count | Desired count of services to be started/running. | `number` | `0` | no |
 | ecr | ECR repository configuration. | <pre>object({<br>    image_scanning_configuration = object({<br>      scan_on_push = bool<br>    })<br>    image_tag_mutability = string,<br>  })</pre> | <pre>{<br>  "image_scanning_configuration": {<br>    "scan_on_push": false<br>  },<br>  "image_tag_mutability": "MUTABLE"<br>}</pre> | no |
-| health\_check\_endpoint | Endpoint (/health) that will be probed by the LB to determine the service's health. | `string` | n/a | yes |
+| health\_check | A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults. | `map(string)` | `{}` | no |
 | logs\_domain\_name | The name of an existing Elasticsearch domain used as destination for the Firehose delivery stream. | `string` | `"application-logs"` | no |
 | logs\_firehose\_delivery\_stream\_s3\_backup\_bucket\_arn | Use an existing S3 bucket to backup log documents which couldn't be streamed to Elasticsearch. Otherwise a separate bucket for this service will be created. | `string` | `""` | no |
 | logs\_fluentbit\_cloudwatch\_log\_group\_name | Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created. | `string` | `""` | no |

--- a/examples/public-service/main.tf
+++ b/examples/public-service/main.tf
@@ -12,7 +12,6 @@ module "service" {
   create_deployment_pipeline = false
   create_log_streaming       = false
   desired_count              = 1
-  health_check_endpoint      = "/"
   service_name               = local.service_name
   container_definitions      = <<DOC
 [
@@ -45,5 +44,9 @@ DOC
     image_scanning_configuration = {
       scan_on_push = true
     }
+  }
+
+  health_check = {
+    path = "/"
   }
 }

--- a/examples/public-service/main.tf
+++ b/examples/public-service/main.tf
@@ -5,7 +5,6 @@ locals {
 module "service" {
   source = "../../"
 
-  alb_listener_priority      = 777
   assign_public_ip           = true
   cluster_id                 = "k8"
   container_port             = 80

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,10 +20,10 @@ output "kinesis_firehose_delivery_stream_name" {
 
 output "private_dns" {
   description = "Private DNS entry."
-  value       = "${aws_route53_record.internal.name}.${data.aws_route53_zone.internal.name}"
+  value       = var.alb_attach_public_target_group ? "${aws_route53_record.internal[0].name}.${data.aws_route53_zone.internal[0].name}" : ""
 }
 
 output "public_dns" {
   description = "Public DNS entry."
-  value       = "${aws_route53_record.external.name}.${data.aws_route53_zone.external.name}"
+  value       = var.alb_attach_public_target_group ? "${aws_route53_record.external[0].name}.${data.aws_route53_zone.external[0].name}" : ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "alb_listener_priority" {
-  description = "Ordering of listeners, must be unique."
-  type        = number
-}
-
 variable "cluster_id" {
   description = "The ECS cluster id that should run this service"
   type        = string
@@ -44,6 +39,12 @@ variable "alb_attach_private_target_group" {
   default     = true
   description = "Attach a target group for this service to the private ALB (requires an ALB with `name=private`)."
   type        = bool
+}
+
+variable "alb_listener_priority" {
+  default     = null
+  description = "The priority for the ALB listener rule between 1 and 50000. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule."
+  type        = number
 }
 
 variable "assign_public_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,11 +24,6 @@ variable "container_port" {
   type        = number
 }
 
-variable "health_check_endpoint" {
-  description = "Endpoint (/health) that will be probed by the LB to determine the service's health."
-  type        = string
-}
-
 variable "service_name" {
   description = "The service name. Will also be used as Route53 DNS entry."
   type        = string
@@ -38,6 +33,18 @@ variable "service_name" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+
+variable "alb_attach_public_target_group" {
+  default     = true
+  description = "Attach a target group for this service to the public ALB (requires an ALB with `name=public`)."
+  type        = bool
+}
+
+variable "alb_attach_private_target_group" {
+  default     = true
+  description = "Attach a target group for this service to the private ALB (requires an ALB with `name=private`)."
+  type        = bool
+}
 
 variable "assign_public_ip" {
   default     = false
@@ -122,6 +129,12 @@ variable "ecr" {
     }
     image_tag_mutability = "MUTABLE",
   }
+}
+
+variable "health_check" {
+  description = "A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults."
+  default     = {}
+  type        = map(string)
 }
 
 variable "logs_firehose_delivery_stream_s3_backup_bucket_arn" {


### PR DESCRIPTION
In order to support services which don't need to be attached to an ALB target group (e.g. services in an App Mesh using grpc), the following adjustments have been made:

- `health_check` is now an optional map to capture configuration supported for a [aws_lb_target_group ](https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check)
- `alb_listener_priority` is now optional
- new variable `alb_attach_public_target_group` to attach the service to the public ALB and create a Route53 record (defaults to `true`)
- new variable `alb_attach_private_target_group` to attach the service to the private ALB and create a Route53 record (defaults to `true`)

This needs to be released as a `MINOR` version (`health_check` needs to be adjusted in clients)