### PR TITLE
Auth for the public ALB's HTTPS listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ That CodePipeline will do the heavy lifting (see deployment flow above):
 
 ## Todos
 
-* [ ] Cognito auth for ALB listeners
+* [x] Cognito auth for ALB listeners
 * [x] CodeDeploy with ECR trigger
 * [ ] ECR policies
 * [ ] Notification for the deployment pipeline [success/failure] 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
 | alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
+| alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `null` | no |
+| alb\_cogino\_pool\_client\_id | COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
+| alb\_cogino\_pool\_domain | COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
 | alb\_listener\_priority | The priority for the ALB listener rule between 1 and 50000. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. | `number` | `null` | no |
 | assign\_public\_ip | As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service. | `bool` | `false` | no |
 | cluster\_id | The ECS cluster id that should run this service | `string` | n/a | yes |
@@ -258,3 +261,57 @@ No requirements.
 | private\_dns | Private DNS entry. |
 | public\_dns | Public DNS entry. |
 
+Requirements
+------------
+
+Documentation is generated with `brew install terraform-docs`
+
+The following resources are referenced from this module and therefore prerequisites:
+
+* VPC — There must be a VPC with the following tag: `Name = main`
+* Subnets — within this VPC, there must be at least one subnet tagged with `Tier = (public|private)`
+* SG (1) — within this VPC there must be a security group `Name = default`
+* SG (2) — within this VPC there must be a security group to allow traffic from ALB `Name = fargate-allow-alb-traffic`
+* DNS (VPC) — within this VPC there must be a private route53 zone with `name = vpc.internal.`
+* DNS (public) — currently there is a hard-coded route53 zone `name = buzz.t-online.delivery.`
+* ALB — there must be ALBs with `name = (public|private)`. 
+* ALB Listeners — Those ALBs should have listeners for HTTP(s) (Port `80` and `443`) configured
+* IAM role — There should be a role named `ssm_ecs_task_execution_role` that will be used as a task execution role
+* Service discovery namespace `apps.local.` 
+
+### When using the automated deployment pipeline (optional):
+
+* A shared S3 bucket for storing artifacts from _CodePipeline_ can be used. You can specify
+it through the variable `code_pipeline_artifact_bucket`. Otherwise a new bucket is created 
+for every service.
+* A shared `IAM::Role` for _CodePipeline_ and _CodeBuild_ can be used. You can specify
+those through the variables `code_pipeline_role_name` and `code_build_role_name`. Otherwise new 
+roles are created for every service. For the permissions required see the [module code](./modules/deployment)
+ 
+
+### Naming Conventions
+
+- Service Names `var.service_name = [a-z-]+`
+
+### Automated Service Deployment
+
+Once `create_deployment_pipeline` is set to `true`, we will create an automated Deployment Pipeline:
+
+![deployment pipeline](docs/ecs_deployer.png)
+
+How it works:
+
+- You'll need AWS credentials that allow pushing images into the ECR container registry.
+- Once you push an image with `[tag=production]` - a Cloudwatch Event will trigger the start of a CodePipeline
+- **⚠ This tag will only trigger the pipeline. You will need a minimum of 3 tags**
+1. `production` will trigger the pipeline
+2. `container.$CONTAINER_NAME` is required to locate the correct container from the service's [task-definition.json](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html)
+3.  One more tag that will be unique and used for the actual deployment and the task-definition.json. A good
+choice would be `git.sha`. To be specific, we chose a tag that does not `start with container.` and is none 
+of `["local", "production", "staging", "infrastructure"]`
+
+- That CodePipeline will do the heavy lifting (see deployment flow above):
+
+1. Pull the full `imagedefinitions.json` from the ECR registry
+2. Trigger a CodeBuild to transform the `imagedefinitions.json` into a `imagedefinitions.json` for deployment
+3. Update the ECS service's task-definition by replacing the specified `imageUri` for the given `name`.

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
 | alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
-| alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `null` | no |
-| alb\_cogino\_pool\_client\_id | COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
-| alb\_cogino\_pool\_domain | COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
+| alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `""` | no |
+| alb\_cogino\_pool\_client\_id | COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `""` | no |
+| alb\_cogino\_pool\_domain | COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `""` | no |
 | alb\_listener\_priority | The priority for the ALB listener rule between 1 and 50000. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. | `number` | `null` | no |
 | assign\_public\_ip | As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service. | `bool` | `false` | no |
 | cluster\_id | The ECS cluster id that should run this service | `string` | n/a | yes |

--- a/alb.tf
+++ b/alb.tf
@@ -49,7 +49,7 @@ resource "aws_alb_listener_rule" "public" {
   priority     = var.alb_listener_priority
 
   dynamic "action" {
-    for_each = var.alb_cogino_pool_arn == null ? [/*noop*/] : ["enabled"]
+    for_each = var.alb_cogino_pool_arn == "" ? [/*noop*/] : ["enabled"]
     content {
       type = "authenticate-cognito"
       authenticate_cognito {

--- a/alb.tf
+++ b/alb.tf
@@ -48,6 +48,18 @@ resource "aws_alb_listener_rule" "public" {
   listener_arn = data.aws_lb_listener.public[count.index].arn
   priority     = var.alb_listener_priority
 
+  dynamic "action" {
+    for_each = var.alb_cogino_pool_arn == null ? [/*noop*/] : ["enabled"]
+    content {
+      type = "authenticate-cognito"
+      authenticate_cognito {
+        user_pool_arn       = var.alb_cogino_pool_arn
+        user_pool_client_id = var.alb_cogino_pool_client_id
+        user_pool_domain    = var.alb_cogino_pool_domain
+      }
+    }
+  }
+
   action {
     type             = "forward"
     target_group_arn = aws_alb_target_group.public[count.index].arn

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -202,7 +202,7 @@ That CodePipeline will do the heavy lifting (see deployment flow above):
 
 ## Todos
 
-* [ ] Cognito auth for ALB listeners
+* [x] Cognito auth for ALB listeners
 * [x] CodeDeploy with ECR trigger
 * [ ] ECR policies
 * [ ] Notification for the deployment pipeline [success/failure] 

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -15,6 +15,9 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
 | alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
+| alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `null` | no |
+| alb\_cogino\_pool\_client\_id | COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
+| alb\_cogino\_pool\_domain | COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
 | alb\_listener\_priority | The priority for the ALB listener rule between 1 and 50000. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. | `number` | `null` | no |
 | assign\_public\_ip | As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service. | `bool` | `false` | no |
 | cluster\_id | The ECS cluster id that should run this service | `string` | n/a | yes |

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -15,9 +15,9 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
 | alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
-| alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `null` | no |
-| alb\_cogino\_pool\_client\_id | COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
-| alb\_cogino\_pool\_domain | COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `null` | no |
+| alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `""` | no |
+| alb\_cogino\_pool\_client\_id | COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `""` | no |
+| alb\_cogino\_pool\_domain | COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener. | `string` | `""` | no |
 | alb\_listener\_priority | The priority for the ALB listener rule between 1 and 50000. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. | `number` | `null` | no |
 | assign\_public\_ip | As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service. | `bool` | `false` | no |
 | cluster\_id | The ECS cluster id that should run this service | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -49,19 +49,19 @@ variable "alb_listener_priority" {
 
 variable "alb_cogino_pool_arn" {
   type        = string
-  default     = null
+  default     = ""
   description = "Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth."
 }
 
 variable "alb_cogino_pool_client_id" {
   type        = string
-  default     = null
+  default     = ""
   description = "COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener."
 }
 
 variable "alb_cogino_pool_domain" {
   type        = string
-  default     = null
+  default     = ""
   description = "COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,24 @@ variable "alb_listener_priority" {
   type        = number
 }
 
+variable "alb_cogino_pool_arn" {
+  type        = string
+  default     = null
+  description = "Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth."
+}
+
+variable "alb_cogino_pool_client_id" {
+  type        = string
+  default     = null
+  description = "COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener."
+}
+
+variable "alb_cogino_pool_domain" {
+  type        = string
+  default     = null
+  description = "COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener."
+}
+
 variable "assign_public_ip" {
   default     = false
   description = "As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service."


### PR DESCRIPTION
User can activate COGNITO authentication by passing:
```
module "service" {
  # ...
  alb_cogino_pool_arn           = data.terraform_remote_state.cognito.outputs.alb_cogino_pool_arn
  alb_cogino_pool_client_id     = data.terraform_remote_state.cognito.outputs.alb_cogino_pool_client_id
  alb_cogino_pool_domain        = data.terraform_remote_state.cognito.outputs.alb_cogino_pool_domain
}
```