### PR TITLE
manage cloudwatch logs for code build

### DIFF
--- a/modules/deployment/code_build.tf
+++ b/modules/deployment/code_build.tf
@@ -1,3 +1,10 @@
+resource "aws_cloudwatch_log_group" "this" {
+  count             = var.enabled ? 1 : 0
+  name              = "/aws/codebuild/${var.service_name}-deployment"
+  retention_in_days = 7
+  tags              = var.tags
+}
+
 resource "aws_codebuild_project" "this" {
   count        = var.enabled ? 1 : 0
   name         = "${var.service_name}-deployment"
@@ -8,6 +15,17 @@ resource "aws_codebuild_project" "this" {
     type                = "CODEPIPELINE"
     artifact_identifier = "deploy_output"
     location            = "imagedefinitions.json"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name = aws_cloudwatch_log_group.this[count.index].name
+      status     = "ENABLED"
+    }
+
+    s3_logs {
+      status = "DISABLED"
+    }
   }
 
   environment {


### PR DESCRIPTION
Before this PR CodeBuild created CloudWatch log groups automatically (without a retention time and tags). As a consequence those log groups remained after a `terraform destroy`.

With this PR we manage those log groups with terraform. To apply this to existing services, please delete automatically create log groups manually before `terraform apply`. 