### PR TITLE
send logs directly to Elasticsearch

### DIFF
--- a/docs/part1.md
+++ b/docs/part1.md
@@ -7,8 +7,7 @@ A somewhat opinionated Terraform module to create Fargate ECS resources on AWS.
 This module does the heavy lifting for: 
 * [ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html) configuration
 * [automated service deployment](#Automated-service-deployment) including notifications
-* [log routing](https://docs.amazonaws.cn/en_us/AmazonECS/latest/developerguide/using_firelens.html) to an Elasticsearch domain using 
-[Amazon Kinesis Data Firehose delivery streams](https://docs.amazonaws.cn/en_us/AmazonECS/latest/developerguide/using_firelens.html#firelens-example-firehose) and [Fluent-Bit](https://fluentbit.io/)
+* IAM permissions for sending logs to an Elasticsearch domain using Firelens with [Fluent-Bit](https://fluentbit.io/)
 * integration with [App Mesh](https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html) and [Application Load Balancers](#Load-Balancing) 
 
 ## Requirements
@@ -93,18 +92,19 @@ locals {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-data "aws_iam_policy_document" "policy" {  
-  statement {
-    actions = ["firehose:PutRecordBatch"] 
-    resources = ["*"]
-  }
+data "aws_elasticsearch_domain" "elasticsearch" {
+  domain_name = "application-logs"
+}
+
+data "aws_ssm_parameter" "fluent_bit_image" {
+  name = "/aws/service/aws-for-fluent-bit/latest"
 }
 
 module "service" {
   source  = "stroeer/ecs-fargate/aws"
   version = "0.8.0"
 
-  cluster_id                    = "k8"s
+  cluster_id                    = "k8"
   container_port                = 8080  
   desired_count                 = 1
   service_name                  = local.service_name
@@ -116,9 +116,9 @@ module "service" {
   container_definitions         = <<DOC
 [
   {
-    "essential": true,
-    "image": "906394416424.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/aws-for-fluent-bit:latest",
     "name": "log_router",
+    "essential": true,
+    "image": "${data.aws_ssm_parameter.fluent_bit_image.value}",
     "firelensConfiguration": {
         "type": "fluentbit",
         "options": {
@@ -129,12 +129,12 @@ module "service" {
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-            "awslogs-group": "firelens-container",
+            "awslogs-group": "${module.service.fluentbit_cloudwatch_log_group}",
             "awslogs-region": "${data.aws_region.current.name}",
-            "awslogs-stream-prefix": "firelens"
+            "awslogs-stream-prefix": "${local.service_name}-firelens"
         }
-    },
-    "memoryReservation": 50
+     },
+    "user": "0"
   },
   {
     "name": "${local.service_name}",
@@ -144,12 +144,18 @@ module "service" {
     "essential": true,
     "portMappings": [ {"containerPort": 8080, "protocol": "tcp"} ],
     "logConfiguration": {
-      "logDriver": "awsfirelens",
-      "options": {
-        "Name": "firehose",
-        "region": "${data.aws_region.current.name}",
-        "delivery_stream": "${module.service.kinesis_firehose_delivery_stream_name}"
-      }    
+        "logDriver": "awsfirelens",
+        "options": {
+          "Name": "es",
+          "Host": "${data.aws_elasticsearch_domain.elasticsearch.endpoint}",
+          "Port": "443",
+          "Aws_Auth": "On",
+          "Aws_Region": "${data.aws_region.current.name}",
+          "tls": "On",
+          "Logstash_Format": "true",
+          "Logstash_Prefix": "${local.service_name}-app"
+        }
+     }    
   }
 ]
 DOC

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -32,13 +32,11 @@ No requirements.
 | container\_port | The port used by the web app within the container | `number` | n/a | yes |
 | cpu | Amount of CPU required by this service. 1024 == 1 vCPU | `number` | `256` | no |
 | create\_deployment\_pipeline | Creates a deploy pipeline from ECR trigger. | `bool` | `true` | no |
-| create\_log\_streaming | Creates a Kinesis Firehose delivery stream for streaming application logs to an existing Elasticsearch domain. | `bool` | `true` | no |
 | desired\_count | Desired count of services to be started/running. | `number` | `0` | no |
 | ecr | ECR repository configuration. | <pre>object({<br>    image_scanning_configuration = object({<br>      scan_on_push = bool<br>    })<br>    image_tag_mutability = string,<br>  })</pre> | <pre>{<br>  "image_scanning_configuration": {<br>    "scan_on_push": false<br>  },<br>  "image_tag_mutability": "MUTABLE"<br>}</pre> | no |
 | force\_new\_deployment | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered\_placement\_strategy and placement\_constraints updates. | `bool` | `false` | no |
 | health\_check | A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults. | `map(string)` | `{}` | no |
-| logs\_domain\_name | The name of an existing Elasticsearch domain used as destination for the Firehose delivery stream. | `string` | `"application-logs"` | no |
-| logs\_firehose\_delivery\_stream\_s3\_backup\_bucket\_arn | Use an existing S3 bucket to backup log documents which couldn't be streamed to Elasticsearch. Otherwise a separate bucket for this service will be created. | `string` | `""` | no |
+| logs\_elasticsearch\_domain\_arn | Amazon Resource Name (ARN) of an existing Elasticsearch domain. IAM permissions for sending logs to this domain will be added. | `string` | `""` | no |
 | logs\_fluentbit\_cloudwatch\_log\_group\_name | Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created. | `string` | `""` | no |
 | memory | Amount of memory [MB] is required by this service. | `number` | `512` | no |
 | platform\_version | The platform version on which to run your service. Defaults to LATEST. | `string` | `"LATEST"` | no |
@@ -56,7 +54,6 @@ No requirements.
 | ecr\_repository\_url | URL of the ECR repository |
 | ecs\_task\_exec\_role\_name | ECS task role used by this service. |
 | fluentbit\_cloudwatch\_log\_group | Name of the CloudWatch log group of the fluent-bit sidecar. |
-| kinesis\_firehose\_delivery\_stream\_name | The name of the Kinesis Firehose delivery stream. |
 | private\_dns | Private DNS entry. |
 | public\_dns | Public DNS entry. |
 

--- a/main.tf
+++ b/main.tf
@@ -125,13 +125,11 @@ module "code_deploy" {
 }
 
 module "logs" {
-  source  = "./modules/logs"
-  enabled = var.create_log_streaming
+  source = "./modules/logs"
 
-  domain_name                                   = var.logs_domain_name
-  firehose_delivery_stream_s3_backup_bucket_arn = var.logs_firehose_delivery_stream_s3_backup_bucket_arn
-  fluentbit_cloudwatch_log_group_name           = var.logs_fluentbit_cloudwatch_log_group_name
-  service_name                                  = var.service_name
-  tags                                          = local.tags
-  task_role_name                                = aws_iam_role.ecs_task_role.name
+  elasticsearch_domain_arn            = var.logs_elasticsearch_domain_arn
+  fluentbit_cloudwatch_log_group_name = var.logs_fluentbit_cloudwatch_log_group_name
+  service_name                        = var.service_name
+  tags                                = local.tags
+  task_role_name                      = aws_iam_role.ecs_task_role.name
 }

--- a/modules/logs/main.tf
+++ b/modules/logs/main.tf
@@ -1,175 +1,31 @@
-locals {
-  index_name = "${var.service_name}-app"
-}
-
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-
-# see https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-es
-data "aws_iam_policy_document" "stream_policy" {
-  count = var.enabled ? 1 : 0
+data "aws_iam_policy_document" "es_policy" {
+  count = var.elasticsearch_domain_arn != "" ? 1 : 0
 
   statement {
     actions = [
-      "s3:AbortMultipartUpload",
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:ListBucketMultipartUploads",
-      "s3:PutObject"
+      "es:*"
     ]
     resources = [
-      "arn:aws:s3:::${module.s3_firehose.this_s3_bucket_id}",
-      "arn:aws:s3:::${module.s3_firehose.this_s3_bucket_id}/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "es:DescribeElasticsearchDomain",
-      "es:DescribeElasticsearchDomains",
-      "es:DescribeElasticsearchDomainConfig",
-      "es:ESHttpPost",
-      "es:ESHttpPut"
-
-    ]
-    resources = [
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "es:ESHttpGet"
-    ]
-
-    resources = [
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_all/_settings",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_cluster/stats",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/${local.index_name}*/_mapping/type-name",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_nodes",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_nodes/stats",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_nodes/*/stats",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_stats",
-      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/${local.index_name}*/_stats"
+      var.elasticsearch_domain_arn,
+      "${var.elasticsearch_domain_arn}/*"
     ]
   }
 }
 
-data "aws_iam_policy_document" "firehose_policy" {
-  count = var.enabled ? 1 : 0
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["firehose.amazonaws.com"]
-    }
-  }
+resource "aws_iam_policy" "es_policy" {
+  count  = var.elasticsearch_domain_arn != "" ? 1 : 0
+  path   = "/ecs/task-role/"
+  policy = data.aws_iam_policy_document.es_policy[count.index].json
 }
 
-resource "aws_iam_role" "firehose_role" {
-  count              = var.enabled ? 1 : 0
-  assume_role_policy = data.aws_iam_policy_document.firehose_policy[count.index].json
-  description        = "IAM permissions for ${var.service_name} as Firehose delivery stream to Elasticsearch."
-  name               = "firehose_ess_role_${var.service_name}-${data.aws_region.current.name}"
-  path               = "/ecs/logging/"
-
-  tags = merge(var.tags, {
-    tf_module = basename(path.module)
-  })
-}
-
-
-resource "aws_iam_policy" "stream_policy" {
-  count  = var.enabled ? 1 : 0
-  policy = data.aws_iam_policy_document.stream_policy[count.index].json
-}
-
-resource "aws_iam_role_policy_attachment" "stream_policy_attachment" {
-  count      = var.enabled ? 1 : 0
-  role       = aws_iam_role.firehose_role[count.index].name
-  policy_arn = aws_iam_policy.stream_policy[count.index].arn
-}
-
-module "s3_firehose" {
-  source        = "terraform-aws-modules/s3-bucket/aws"
-  create_bucket = var.enabled && var.firehose_delivery_stream_s3_backup_bucket_arn == ""
-
-  bucket        = "failed-documents-${var.service_name}-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
-  acl           = "private"
-  force_destroy = true
-
-  versioning = {
-    enabled = false
-  }
-
-  tags = merge(var.tags, {
-    tf_module = basename(path.module)
-  })
-}
-
-data "aws_elasticsearch_domain" "elasticsearch" {
-  count       = var.enabled ? 1 : 0
-  domain_name = var.domain_name
-}
-
-resource "aws_kinesis_firehose_delivery_stream" "elasticsearch_stream" {
-  count       = var.enabled ? 1 : 0
-  name        = "${var.service_name}-stream"
-  destination = "elasticsearch"
-
-  elasticsearch_configuration {
-    domain_arn            = data.aws_elasticsearch_domain.elasticsearch[count.index].arn
-    index_name            = local.index_name
-    index_rotation_period = "OneDay"
-    role_arn              = aws_iam_role.firehose_role[count.index].arn
-    s3_backup_mode        = "FailedDocumentsOnly"
-
-    cloudwatch_logging_options {
-      enabled = false
-    }
-  }
-
-  s3_configuration {
-    bucket_arn         = var.firehose_delivery_stream_s3_backup_bucket_arn != "" ? var.firehose_delivery_stream_s3_backup_bucket_arn : module.s3_firehose.this_s3_bucket_arn
-    compression_format = "GZIP"
-    prefix             = var.firehose_delivery_stream_s3_backup_bucket_arn != "" ? "${var.service_name}/" : ""
-    role_arn           = aws_iam_role.firehose_role[count.index].arn
-    # kms_key_arn = "todo with default key from data to enable encryption"
-
-    cloudwatch_logging_options {
-      enabled = false
-    }
-  }
-
-  tags = merge(var.tags, {
-    tf_module = basename(path.module)
-  })
-}
-
-data "aws_iam_policy_document" "firehose_task_policy" {
-  count = var.enabled ? 1 : 0
-  statement {
-    actions   = ["firehose:PutRecordBatch"]
-    resources = [aws_kinesis_firehose_delivery_stream.elasticsearch_stream[count.index].arn]
-  }
-}
-
-resource "aws_iam_policy" "firehose_task_policy" {
-  count  = var.enabled ? 1 : 0
-  policy = data.aws_iam_policy_document.firehose_task_policy[count.index].json
-}
-
-resource "aws_iam_role_policy_attachment" "firehose_task_policy_attachment" {
-  count      = var.enabled ? 1 : 0
+resource "aws_iam_role_policy_attachment" "es_policy_attachment" {
+  count      = var.elasticsearch_domain_arn != "" ? 1 : 0
   role       = var.task_role_name
-  policy_arn = aws_iam_policy.firehose_task_policy[count.index].arn
+  policy_arn = aws_iam_policy.es_policy[count.index].arn
 }
 
 resource "aws_cloudwatch_log_group" "fluentbit" {
-  count             = var.enabled && var.fluentbit_cloudwatch_log_group_name == "" ? 1 : 0
+  count             = var.elasticsearch_domain_arn != "" && var.fluentbit_cloudwatch_log_group_name == "" ? 1 : 0
   name              = "/aws/ecs/${var.service_name}-fluentbit-container"
   retention_in_days = 7
 
@@ -177,4 +33,3 @@ resource "aws_cloudwatch_log_group" "fluentbit" {
     tf_module = basename(path.module)
   })
 }
-

--- a/modules/logs/outputs.tf
+++ b/modules/logs/outputs.tf
@@ -1,9 +1,4 @@
 output "fluentbit_cloudwatch_log_group" {
   description = "Name of the CloudWatch log group of the fluent-bit sidecar."
-  value       = var.enabled && var.fluentbit_cloudwatch_log_group_name == "" ? element(aws_cloudwatch_log_group.fluentbit.*.name, 0) : ""
-}
-
-output "kinesis_firehose_delivery_stream_name" {
-  description = "The name to identify the stream."
-  value       = length(aws_kinesis_firehose_delivery_stream.elasticsearch_stream) == 0 ? "" : element(aws_kinesis_firehose_delivery_stream.elasticsearch_stream.*.name, 0)
+  value       = var.elasticsearch_domain_arn != "" && var.fluentbit_cloudwatch_log_group_name == "" ? element(aws_cloudwatch_log_group.fluentbit.*.name, 0) : ""
 }

--- a/modules/logs/variables.tf
+++ b/modules/logs/variables.tf
@@ -3,8 +3,8 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "domain_name" {
-  description = "The name of an existing Elasticsearch domain used as destination for the Firehose delivery stream."
+variable "elasticsearch_domain_arn" {
+  description = "Amazon Resource Name (ARN) of an existing Elasticsearch domain. IAM permissions for sending logs to this domain will be added."
   type        = string
 }
 
@@ -14,7 +14,7 @@ variable "service_name" {
 }
 
 variable "task_role_name" {
-  description = "Name of the IAM role used by the containers in a task. Firehose and CloudWatch Log policies will be attached to this role."
+  description = "Name of the IAM role used by the containers in this service. IAM permissions for sending logs to Elasticsearch will be added to this role."
   type        = string
 }
 
@@ -22,18 +22,6 @@ variable "task_role_name" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
-
-variable "enabled" {
-  default     = true
-  description = "Conditionally enables this module (and all it's ressources)."
-  type        = bool
-}
-
-variable "firehose_delivery_stream_s3_backup_bucket_arn" {
-  default     = ""
-  description = "Use an existing S3 bucket to backup log documents which couldn't be streamed to Elasticsearch. Otherwise a separate bucket for this service will be created."
-  type        = string
-}
 
 variable "fluentbit_cloudwatch_log_group_name" {
   default     = ""
@@ -43,6 +31,6 @@ variable "fluentbit_cloudwatch_log_group_name" {
 
 variable "tags" {
   default     = {}
-  description = "A mapping of tags to assign to the Kinesis Firehose resource."
+  description = "A mapping of tags to assign to the created resources."
   type        = map(string)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,11 +13,6 @@ output "ecr_repository_url" {
   value       = module.ecr.repository_url
 }
 
-output "kinesis_firehose_delivery_stream_name" {
-  description = "The name of the Kinesis Firehose delivery stream."
-  value       = module.logs.kinesis_firehose_delivery_stream_name
-}
-
 output "private_dns" {
   description = "Private DNS entry."
   value       = var.alb_attach_private_target_group ? "${aws_route53_record.internal[0].name}.${data.aws_route53_zone.internal[0].name}" : ""

--- a/variables.tf
+++ b/variables.tf
@@ -137,12 +137,6 @@ variable "create_deployment_pipeline" {
   type        = bool
 }
 
-variable "create_log_streaming" {
-  default     = true
-  description = "Creates a Kinesis Firehose delivery stream for streaming application logs to an existing Elasticsearch domain."
-  type        = bool
-}
-
 variable "desired_count" {
   default     = 0
   description = "Desired count of services to be started/running."
@@ -180,21 +174,15 @@ variable "health_check" {
   type        = map(string)
 }
 
-variable "logs_firehose_delivery_stream_s3_backup_bucket_arn" {
+variable "logs_elasticsearch_domain_arn" {
+  description = "Amazon Resource Name (ARN) of an existing Elasticsearch domain. IAM permissions for sending logs to this domain will be added."
   default     = ""
-  description = "Use an existing S3 bucket to backup log documents which couldn't be streamed to Elasticsearch. Otherwise a separate bucket for this service will be created."
+  type        = string
 }
 
 variable "logs_fluentbit_cloudwatch_log_group_name" {
   default     = ""
   description = "Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created."
-  type        = string
-}
-
-
-variable "logs_domain_name" {
-  default     = "application-logs"
-  description = "The name of an existing Elasticsearch domain used as destination for the Firehose delivery stream."
   type        = string
 }
 


### PR DESCRIPTION
with Fluent-Bit 1.5 we can now send logs directly to Elasticsearch - support for Kinesis Firehose is dropped. See [fluent-bit](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) documentation for configuration details  and options.

**This should be released as a new minor version and applied to all clients**

fixes #28