### PR TITLE
support additional security groups for ecs service

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_security\_group\_ids | Additional security groups this service should also be added to. | `list(string)` | `[]` | no |
 | alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
 | alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
 | alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `""` | no |

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -13,6 +13,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_security\_group\_ids | Additional security groups this service should also be added to. | `list(string)` | `[]` | no |
 | alb\_attach\_private\_target\_group | Attach a target group for this service to the private ALB (requires an ALB with `name=private`). | `bool` | `true` | no |
 | alb\_attach\_public\_target\_group | Attach a target group for this service to the public ALB (requires an ALB with `name=public`). | `bool` | `true` | no |
 | alb\_cogino\_pool\_arn | Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   alb_public_group  = var.alb_attach_public_target_group && length(aws_alb_target_group.public) == 1 ? list(aws_alb_target_group.public[0].arn) : []
   alb_private_group = var.alb_attach_private_target_group && length(aws_alb_target_group.private) == 1 ? list(aws_alb_target_group.private[0].arn) : []
+  security_groups   = compact(concat(list(data.aws_security_group.default.id, data.aws_security_group.fargate.id), var.additional_security_group_ids))
 }
 
 data "aws_subnet_ids" "selected" {
@@ -48,7 +49,7 @@ resource "aws_ecs_service" "this" {
 
   network_configuration {
     subnets          = data.aws_subnet_ids.selected.ids
-    security_groups  = [data.aws_security_group.default.id, data.aws_security_group.fargate.id]
+    security_groups  = local.security_groups
     assign_public_ip = var.assign_public_ip
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "service_name" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "additional_security_group_ids" {
+  description = "Additional security groups this service should also be added to."
+  default     = []
+  type        = list(string)
+}
+
 variable "alb_attach_public_target_group" {
   default     = true
   description = "Attach a target group for this service to the public ALB (requires an ALB with `name=public`)."


### PR DESCRIPTION
we'll use this for example to send logs to Elasticsearch