### PR TITLE
removed datasource because it fails when bootstrapping new services and replaced it with manual ARN build

### DIFF
--- a/modules/deployment/data.tf
+++ b/modules/deployment/data.tf
@@ -1,10 +1,6 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-data "aws_ecr_repository" "this" {
-  name = var.ecr_repository_name
-}
-
 data "aws_iam_role" "code_build" {
   count = var.enabled && var.code_build_role != "" ? 1 : 0
   name  = var.code_build_role

--- a/modules/deployment/iam_code_pipeline.tf
+++ b/modules/deployment/iam_code_pipeline.tf
@@ -43,7 +43,8 @@ data "aws_iam_policy_document" "code_pipepline_permissions" {
   statement {
     actions = ["ecr:DescribeImages"]
 
-    resources = [data.aws_ecr_repository.this.arn]
+    resources = [
+    "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"]
   }
 
   statement {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12.17, < 0.14"
+
+  required_providers {
+    aws = ">= 3.0, < 4.0"
+  }
+}


### PR DESCRIPTION
```
module.service.module.code_deploy.aws_iam_role_policy_attachment.trigger[0]: Refreshing state... [id=xxx]
aremoved datasource because it fails when bootstrapping new services and replaced it with manual ARN build

Error: ECR Repository (xxx) not found
```