### PR TITLE
central CloudWatch log group for a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This module does the heavy lifting for:
 * [ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html) configuration
 * [automated service deployment](#Automated-service-deployment) including notifications
 * IAM permissions for sending logs to an Elasticsearch domain using Firelens with [Fluent-Bit](https://fluentbit.io/)
+* CloudWatch log group and IAM permissions for storing container logs (e.g. for sitecars)
 * integration with [App Mesh](https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html) and [Application Load Balancers](#Load-Balancing) 
 
 ## Requirements
@@ -59,7 +60,6 @@ module "service" {
 
   cluster_id                    = "k8"
   container_port                = 8080
-  create_log_streaming          = false
   desired_count                 = 1
   service_name                  = local.service_name
 
@@ -129,9 +129,9 @@ module "service" {
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-            "awslogs-group": "${module.service.fluentbit_cloudwatch_log_group}",
+            "awslogs-group": "${module.service.cloudwatch_log_group}",
             "awslogs-region": "${data.aws_region.current.name}",
-            "awslogs-stream-prefix": "${local.service_name}-firelens"
+            "awslogs-stream-prefix": "fluent_bit"
         }
      },
     "user": "0"
@@ -268,7 +268,6 @@ for example.
 | force\_new\_deployment | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered\_placement\_strategy and placement\_constraints updates. | `bool` | `false` | no |
 | health\_check | A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults. | `map(string)` | `{}` | no |
 | logs\_elasticsearch\_domain\_arn | Amazon Resource Name (ARN) of an existing Elasticsearch domain. IAM permissions for sending logs to this domain will be added. | `string` | `""` | no |
-| logs\_fluentbit\_cloudwatch\_log\_group\_name | Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created. | `string` | `""` | no |
 | memory | Amount of memory [MB] is required by this service. | `number` | `512` | no |
 | platform\_version | The platform version on which to run your service. Defaults to LATEST. | `string` | `"LATEST"` | no |
 | policy\_document | AWS Policy JSON describing the permissions required for this service. | `string` | `""` | no |
@@ -281,10 +280,10 @@ for example.
 
 | Name | Description |
 |------|-------------|
+| cloudwatch\_log\_group | Name of the CloudWatch log group for container logs |
 | ecr\_repository\_arn | Full ARN of the ECR repository |
 | ecr\_repository\_url | URL of the ECR repository |
 | ecs\_task\_exec\_role\_name | ECS task role used by this service. |
-| fluentbit\_cloudwatch\_log\_group | Name of the CloudWatch log group of the fluent-bit sidecar. |
 | private\_dns | Private DNS entry. |
 | public\_dns | Public DNS entry. |
 

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -8,6 +8,7 @@ This module does the heavy lifting for:
 * [ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html) configuration
 * [automated service deployment](#Automated-service-deployment) including notifications
 * IAM permissions for sending logs to an Elasticsearch domain using Firelens with [Fluent-Bit](https://fluentbit.io/)
+* CloudWatch log group and IAM permissions for storing container logs (e.g. for sitecars)
 * integration with [App Mesh](https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html) and [Application Load Balancers](#Load-Balancing) 
 
 ## Requirements
@@ -59,7 +60,6 @@ module "service" {
 
   cluster_id                    = "k8"
   container_port                = 8080
-  create_log_streaming          = false
   desired_count                 = 1
   service_name                  = local.service_name
 
@@ -129,9 +129,9 @@ module "service" {
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-            "awslogs-group": "${module.service.fluentbit_cloudwatch_log_group}",
+            "awslogs-group": "${module.service.cloudwatch_log_group}",
             "awslogs-region": "${data.aws_region.current.name}",
-            "awslogs-stream-prefix": "${local.service_name}-firelens"
+            "awslogs-stream-prefix": "fluent_bit"
         }
      },
     "user": "0"

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -40,7 +40,6 @@
 | force\_new\_deployment | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered\_placement\_strategy and placement\_constraints updates. | `bool` | `false` | no |
 | health\_check | A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults. | `map(string)` | `{}` | no |
 | logs\_elasticsearch\_domain\_arn | Amazon Resource Name (ARN) of an existing Elasticsearch domain. IAM permissions for sending logs to this domain will be added. | `string` | `""` | no |
-| logs\_fluentbit\_cloudwatch\_log\_group\_name | Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created. | `string` | `""` | no |
 | memory | Amount of memory [MB] is required by this service. | `number` | `512` | no |
 | platform\_version | The platform version on which to run your service. Defaults to LATEST. | `string` | `"LATEST"` | no |
 | policy\_document | AWS Policy JSON describing the permissions required for this service. | `string` | `""` | no |
@@ -53,10 +52,10 @@
 
 | Name | Description |
 |------|-------------|
+| cloudwatch\_log\_group | Name of the CloudWatch log group for container logs |
 | ecr\_repository\_arn | Full ARN of the ECR repository |
 | ecr\_repository\_url | URL of the ECR repository |
 | ecs\_task\_exec\_role\_name | ECS task role used by this service. |
-| fluentbit\_cloudwatch\_log\_group | Name of the CloudWatch log group of the fluent-bit sidecar. |
 | private\_dns | Private DNS entry. |
 | public\_dns | Public DNS entry. |
 

--- a/examples/public-service/main.tf
+++ b/examples/public-service/main.tf
@@ -9,7 +9,6 @@ module "service" {
   cluster_id                 = "k8"
   container_port             = 80
   create_deployment_pipeline = false
-  create_log_streaming       = false
   desired_count              = 1
   service_name               = local.service_name
   container_definitions      = <<DOC

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_ecs_service" "this" {
   platform_version                   = var.platform_version
   propagate_tags                     = "SERVICE"
   tags                               = local.tags
-  task_definition                    = "${aws_ecs_task_definition.this.family}:${max("${aws_ecs_task_definition.this.revision}", "${data.aws_ecs_task_definition.this.revision}")}"
+  task_definition                    = "${aws_ecs_task_definition.this.family}:${max(aws_ecs_task_definition.this.revision, data.aws_ecs_task_definition.this.revision)}"
 
   dynamic "load_balancer" {
     for_each = concat(local.alb_public_group, local.alb_private_group)
@@ -127,9 +127,8 @@ module "code_deploy" {
 module "logs" {
   source = "./modules/logs"
 
-  elasticsearch_domain_arn            = var.logs_elasticsearch_domain_arn
-  fluentbit_cloudwatch_log_group_name = var.logs_fluentbit_cloudwatch_log_group_name
-  service_name                        = var.service_name
-  tags                                = local.tags
-  task_role_name                      = aws_iam_role.ecs_task_role.name
+  elasticsearch_domain_arn = var.logs_elasticsearch_domain_arn
+  service_name             = var.service_name
+  tags                     = local.tags
+  task_role_name           = aws_iam_role.ecs_task_role.name
 }

--- a/modules/logs/main.tf
+++ b/modules/logs/main.tf
@@ -1,3 +1,7 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM permissions to send logs to AWS Elasticsearch
+# ---------------------------------------------------------------------------------------------------------------------
+
 data "aws_iam_policy_document" "es_policy" {
   count = var.elasticsearch_domain_arn != "" ? 1 : 0
 
@@ -24,12 +28,40 @@ resource "aws_iam_role_policy_attachment" "es_policy_attachment" {
   policy_arn = aws_iam_policy.es_policy[count.index].arn
 }
 
-resource "aws_cloudwatch_log_group" "fluentbit" {
-  count             = var.elasticsearch_domain_arn != "" && var.fluentbit_cloudwatch_log_group_name == "" ? 1 : 0
-  name              = "/aws/ecs/${var.service_name}-fluentbit-container"
+# ---------------------------------------------------------------------------------------------------------------------
+# CloudWatch log group and IAM permissions for container logs (e.g. sidecars)
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "containers" {
+  name              = "/aws/ecs/${var.service_name}"
   retention_in_days = 7
 
   tags = merge(var.tags, {
     tf_module = basename(path.module)
   })
+}
+
+data "aws_iam_policy_document" "cloudwatch_logs_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.containers.arn}:*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cloudwatch_logs_policy" {
+  path   = "/ecs/task-role/"
+  policy = data.aws_iam_policy_document.cloudwatch_logs_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_logs_policy" {
+  role       = var.task_role_name
+  policy_arn = aws_iam_policy.cloudwatch_logs_policy.arn
 }

--- a/modules/logs/outputs.tf
+++ b/modules/logs/outputs.tf
@@ -1,4 +1,4 @@
-output "fluentbit_cloudwatch_log_group" {
-  description = "Name of the CloudWatch log group of the fluent-bit sidecar."
-  value       = var.elasticsearch_domain_arn != "" && var.fluentbit_cloudwatch_log_group_name == "" ? element(aws_cloudwatch_log_group.fluentbit.*.name, 0) : ""
+output "cloudwatch_log_group_name" {
+  description = "Name of the CloudWatch log group for container logs"
+  value       = aws_cloudwatch_log_group.containers.name
 }

--- a/modules/logs/variables.tf
+++ b/modules/logs/variables.tf
@@ -23,12 +23,6 @@ variable "task_role_name" {
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "fluentbit_cloudwatch_log_group_name" {
-  default     = ""
-  description = "Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created."
-  type        = string
-}
-
 variable "tags" {
   default     = {}
   description = "A mapping of tags to assign to the created resources."

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,21 @@
+output "cloudwatch_log_group" {
+  description = "Name of the CloudWatch log group for container logs"
+  value       = module.logs.cloudwatch_log_group_name
+}
+
 output "ecr_repository_arn" {
   description = "Full ARN of the ECR repository"
   value       = module.ecr.arn
 }
 
-output "fluentbit_cloudwatch_log_group" {
-  description = "Name of the CloudWatch log group of the fluent-bit sidecar."
-  value       = module.logs.fluentbit_cloudwatch_log_group
-}
-
 output "ecr_repository_url" {
   description = "URL of the ECR repository"
   value       = module.ecr.repository_url
+}
+
+output "ecs_task_exec_role_name" {
+  description = "ECS task role used by this service."
+  value       = aws_iam_role.ecs_task_role.name
 }
 
 output "private_dns" {
@@ -21,9 +26,4 @@ output "private_dns" {
 output "public_dns" {
   description = "Public DNS entry."
   value       = var.alb_attach_public_target_group ? "${aws_route53_record.external[0].name}.${data.aws_route53_zone.external[0].name}" : ""
-}
-
-output "ecs_task_exec_role_name" {
-  description = "ECS task role used by this service."
-  value       = aws_iam_role.ecs_task_role.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -180,12 +180,6 @@ variable "logs_elasticsearch_domain_arn" {
   type        = string
 }
 
-variable "logs_fluentbit_cloudwatch_log_group_name" {
-  default     = ""
-  description = "Use an existing CloudWatch log group for storing logs of the fluent-bit sidecar. Otherwise a dedicate log group for this service will be created."
-  type        = string
-}
-
 variable "memory" {
   default     = 512
   description = "Amount of memory [MB] is required by this service."


### PR DESCRIPTION
## what

central CloudWatch log group for a service

## why

* all sitecars can store container logs in one log group using prefixes
* IAM permissions centralized in module instead of clients

![image](https://user-images.githubusercontent.com/1858685/99385682-a1a2a980-28d1-11eb-8ab8-c7166321db7d.png)

## deprecations

`logs_fluentbit_cloudwatch_log_group_name`

