### PR TITLE
Fix for logging issues with Fargate 1.4.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "aws_ecs_task_definition" "this" {
       properties = {
         AppPorts         = var.container_port
         EgressIgnoredIPs = "169.254.170.2,169.254.169.254"
-        IgnoredUID       = "1337"
+        IgnoredGID       = "1337"
         ProxyEgressPort  = 15001
         ProxyIngressPort = 15000
       }


### PR DESCRIPTION
See discussion here: https://github.com/aws/aws-app-mesh-roadmap/issues/124#issuecomment-767363794

This is a breaking change, since every service using this module must update the `uid:gid` accordingly:

* `envoy`: `"user": "1337:1337"`
* `fluentbit`: `"user": "0:1337"`