### PR TITLE
Deployment 2.0

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -49,13 +49,13 @@ resource "aws_alb_listener_rule" "public" {
   priority     = var.alb_listener_priority
 
   dynamic "action" {
-    for_each = var.alb_cogino_pool_arn == "" ? [/*noop*/] : ["enabled"]
+    for_each = var.alb_cognito_pool_arn == "" ? [/*noop*/] : ["enabled"]
     content {
       type = "authenticate-cognito"
       authenticate_cognito {
-        user_pool_arn       = var.alb_cogino_pool_arn
-        user_pool_client_id = var.alb_cogino_pool_client_id
-        user_pool_domain    = var.alb_cogino_pool_domain
+        user_pool_arn       = var.alb_cognito_pool_arn
+        user_pool_client_id = var.alb_cognito_pool_client_id
+        user_pool_domain    = var.alb_cognito_pool_domain
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ module "code_deploy" {
   enabled = var.create_deployment_pipeline
 
   cluster_name                          = var.cluster_id
+  container_name                        = local.container_name
   codestar_notifications_detail_type    = var.codestar_notifications_detail_type
   codestar_notifications_event_type_ids = var.codestar_notifications_event_type_ids
   codestar_notifications_target_arn     = var.codestar_notifications_target_arn

--- a/modules/deployment/code_pipeline.tf
+++ b/modules/deployment/code_pipeline.tf
@@ -39,7 +39,7 @@ resource "aws_codepipeline" "codepipeline" {
       provider         = "CodeBuild"
       version          = "1"
       input_artifacts  = ["ecr_source"]
-      output_artifacts = ["build_source"]
+      output_artifacts = ["image_definitions_json"]
 
       configuration = {
         "ProjectName" : aws_codebuild_project.this[count.index].name
@@ -55,7 +55,7 @@ resource "aws_codepipeline" "codepipeline" {
       category        = "Deploy"
       owner           = "AWS"
       provider        = "ECS"
-      input_artifacts = ["build_source"]
+      input_artifacts = ["image_definitions_json"]
       version         = "1"
 
       configuration = {

--- a/modules/deployment/iam_code_pipeline.tf
+++ b/modules/deployment/iam_code_pipeline.tf
@@ -65,26 +65,28 @@ data "aws_iam_policy_document" "code_pipepline_permissions" {
 
   statement {
     actions = [
-      "autoscaling:Describe*",
-      "autoscaling:UpdateAutoScalingGroup",
-      "elasticloadbalancing:*",
-      "ecs:*",
-      "iam:ListInstanceProfiles",
-      "iam:ListRoles",
-      "iam:PassRole"
+      # cloudtrail reports that codepipeline actually requires access to `*`
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition"
     ]
-
     resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecs:UpdateService"
+    ]
+    resources = ["arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/${var.cluster_name}/${var.service_name}"]
   }
 }
 
-resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerServiceFullAccess" {
+resource "aws_iam_role_policy_attachment" "AWSCodeDeployRoleForECS" {
   count      = local.create_code_pipeline_iam ? 1 : 0
   role       = aws_iam_role.code_pipeline_role[count.index].name
-  policy_arn = data.aws_iam_policy.AmazonEC2ContainerServiceFullAccess[count.index].arn
+  policy_arn = data.aws_iam_policy.AWSCodeDeployRoleForECS[count.index].arn
 }
 
-data "aws_iam_policy" "AmazonEC2ContainerServiceFullAccess" {
+data "aws_iam_policy" "AWSCodeDeployRoleForECS" {
   count = local.create_code_pipeline_iam ? 1 : 0
   arn   = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
 }

--- a/modules/deployment/variables.tf
+++ b/modules/deployment/variables.tf
@@ -18,6 +18,11 @@ variable "service_name" {
   description = "The service's name to create the pipeline resources."
 }
 
+variable "container_name" {
+  type        = string
+  description = "The service's main container to create the pipeline resources."
+}
+
 variable "tags" {
   type = map(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,19 +47,19 @@ variable "alb_listener_priority" {
   type        = number
 }
 
-variable "alb_cogino_pool_arn" {
+variable "alb_cognito_pool_arn" {
   type        = string
   default     = ""
   description = "Provide a COGNITO pool ARN if you want to attach COGNITO authentication to the public ALB's HTTPS listener. If not set, there will be no auth."
 }
 
-variable "alb_cogino_pool_client_id" {
+variable "alb_cognito_pool_client_id" {
   type        = string
   default     = ""
   description = "COGNITO client id that will be used for authenticating at the public ALB's HTTPS listener."
 }
 
-variable "alb_cogino_pool_domain" {
+variable "alb_cognito_pool_domain" {
   type        = string
   default     = ""
   description = "COGNITO pool domain that will be used for authenticating at the public ALB's HTTPS listener."
@@ -73,7 +73,7 @@ variable "assign_public_ip" {
 
 variable "container_name" {
   default     = ""
-  description = "Defaults to var.service_name, can be overriden if it differs. Used as a target for LB."
+  description = "Defaults to var.service_name, can be overridden if it differs. Used as a target for LB."
   type        = string
 }
 


### PR DESCRIPTION
*simplified deployment*

- no tags other than the trigger tag are required (`tag:production`)
- task def will use the full image-uri (`...@sha256:...`)
- bumped to latest code build image (v3)

also fixed typo `cognito`

closes #16 