### PR TITLE
fix: apply default ECR lifecycle policy if clients do not specify override

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: [ ~0.13.0, ~0.14.0 , ~0.15.0, ~1.0.0, ~1.1.0 ]
+        terraform: [ ~1.0.0 ]
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform }}
 
-      - uses: terraform-linters/setup-tflint@v1
+      - uses: terraform-linters/setup-tflint@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: |
+      - name: check
+        run: |
           tflint --init
           make fmt validate tflint
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.71.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
       - id: terraform_tflint
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ validate: init ## Validates the Terraform files
 	@AWS_REGION=eu-west-1 terraform validate
 
 .PHONY: tflint
-tflint: ## Runs tflint on all Terraform files
+tflint: init ## Runs tflint on all Terraform files
 	@echo "+ $@"
 	@tflint -f compact || exit 1
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ for example.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.71.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -344,8 +344,8 @@ for example.
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment. | `number` | `100` | no |
 | <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | Desired count of services to be started/running. | `number` | `0` | no |
 | <a name="input_ecr"></a> [ecr](#input\_ecr) | ECR repository configuration. | <pre>object({<br>    image_scanning_configuration = object({<br>      scan_on_push = bool<br>    })<br>    image_tag_mutability = string,<br>  })</pre> | <pre>{<br>  "image_scanning_configuration": {<br>    "scan_on_push": true<br>  },<br>  "image_tag_mutability": "MUTABLE"<br>}</pre> | no |
-| <a name="input_ecr_custom_lifecycle_policy"></a> [ecr\_custom\_lifecycle\_policy](#input\_ecr\_custom\_lifecycle\_policy) | JSON policy for the ecr registry used in aws\_ecr\_lifecycle\_policy. | `string` | `null` | no |
-| <a name="input_ecr_enable_default_lifecycle_policy"></a> [ecr\_enable\_default\_lifecycle\_policy](#input\_ecr\_enable\_default\_lifecycle\_policy) | Default JSON policy for the ecr registry used in aws\_ecr\_lifecycle\_policy. Expires all images except for the last 30. | `bool` | `null` | no |
+| <a name="input_ecr_custom_lifecycle_policy"></a> [ecr\_custom\_lifecycle\_policy](#input\_ecr\_custom\_lifecycle\_policy) | JSON formatted ECR lifecycle policy used for this repository (disabled the default lifecycle policy), see https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters for details. | `string` | `null` | no |
+| <a name="input_ecr_enable_default_lifecycle_policy"></a> [ecr\_enable\_default\_lifecycle\_policy](#input\_ecr\_enable\_default\_lifecycle\_policy) | Enables an ECR lifecycle policy for this repository which expires all images except for the last 30. | `bool` | `true` | no |
 | <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered\_placement\_strategy and placement\_constraints updates. | `bool` | `false` | no |
 | <a name="input_health_check"></a> [health\_check](#input\_health\_check) | A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults. | `map(string)` | `{}` | no |
 | <a name="input_https_listener_rules"></a> [https\_listener\_rules](#input\_https\_listener\_rules) | A list of maps describing the Listener Rules for this ALB. Required key/values: actions, conditions. Optional key/values: priority, https\_listener\_index (default to https\_listeners[count.index]) | `any` | `[]` | no |

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.71.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -74,8 +74,8 @@
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment. | `number` | `100` | no |
 | <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | Desired count of services to be started/running. | `number` | `0` | no |
 | <a name="input_ecr"></a> [ecr](#input\_ecr) | ECR repository configuration. | <pre>object({<br>    image_scanning_configuration = object({<br>      scan_on_push = bool<br>    })<br>    image_tag_mutability = string,<br>  })</pre> | <pre>{<br>  "image_scanning_configuration": {<br>    "scan_on_push": true<br>  },<br>  "image_tag_mutability": "MUTABLE"<br>}</pre> | no |
-| <a name="input_ecr_custom_lifecycle_policy"></a> [ecr\_custom\_lifecycle\_policy](#input\_ecr\_custom\_lifecycle\_policy) | JSON policy for the ecr registry used in aws\_ecr\_lifecycle\_policy. | `string` | `null` | no |
-| <a name="input_ecr_enable_default_lifecycle_policy"></a> [ecr\_enable\_default\_lifecycle\_policy](#input\_ecr\_enable\_default\_lifecycle\_policy) | Default JSON policy for the ecr registry used in aws\_ecr\_lifecycle\_policy. Expires all images except for the last 30. | `bool` | `null` | no |
+| <a name="input_ecr_custom_lifecycle_policy"></a> [ecr\_custom\_lifecycle\_policy](#input\_ecr\_custom\_lifecycle\_policy) | JSON formatted ECR lifecycle policy used for this repository (disabled the default lifecycle policy), see https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters for details. | `string` | `null` | no |
+| <a name="input_ecr_enable_default_lifecycle_policy"></a> [ecr\_enable\_default\_lifecycle\_policy](#input\_ecr\_enable\_default\_lifecycle\_policy) | Enables an ECR lifecycle policy for this repository which expires all images except for the last 30. | `bool` | `true` | no |
 | <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered\_placement\_strategy and placement\_constraints updates. | `bool` | `false` | no |
 | <a name="input_health_check"></a> [health\_check](#input\_health\_check) | A health block containing health check settings for the ALB target groups. See https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#health_check for defaults. | `map(string)` | `{}` | no |
 | <a name="input_https_listener_rules"></a> [https\_listener\_rules](#input\_https\_listener\_rules) | A list of maps describing the Listener Rules for this ALB. Required key/values: actions, conditions. Optional key/values: priority, https\_listener\_index (default to https\_listeners[count.index]) | `any` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -142,13 +142,13 @@ locals {
 module "ecr" {
   source = "./modules/ecr"
 
-  image_scanning_configuration = var.ecr.image_scanning_configuration
-  image_tag_mutability         = var.ecr.image_tag_mutability
-  name                         = var.service_name
-  tags                         = var.tags
-
-  enable_default_lifecycle_policy = var.ecr_enable_default_lifecycle_policy
   custom_lifecycle_policy         = var.ecr_custom_lifecycle_policy
+  enable_default_lifecycle_policy = var.ecr_enable_default_lifecycle_policy
+  image_scanning_configuration    = var.ecr.image_scanning_configuration
+  image_tag_mutability            = var.ecr.image_tag_mutability
+  name                            = var.service_name
+  tags                            = var.tags
+
 }
 
 module "code_deploy" {

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -9,7 +9,7 @@ resource "aws_ecr_repository" "this" {
 }
 
 resource "aws_ecr_lifecycle_policy" "custom_lifecycle_policy" {
-  count      = var.custom_lifecycle_policy != null ? 1 : 0
+  count      = var.custom_lifecycle_policy != null && !var.enable_default_lifecycle_policy ? 1 : 0
   repository = var.name
 
   policy = var.custom_lifecycle_policy
@@ -20,17 +20,17 @@ resource "aws_ecr_lifecycle_policy" "default_lifecycle_policy" {
   repository = var.name
 
   policy = jsonencode({
-    "rules" : [
+    rules : [
       {
-        "rulePriority" : 1,
-        "description" : "Keep last 30 images",
-        "selection" : {
-          "tagStatus" : "any",
-          "countType" : "imageCountMoreThan",
-          "countNumber" : 30
+        rulePriority : 1,
+        description : "Keep last 30 images",
+        selection : {
+          tagStatus : "any",
+          countType : "imageCountMoreThan",
+          countNumber : 30
         },
-        "action" : {
-          "type" : "expire"
+        action : {
+          type : "expire"
         }
       }
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -127,12 +127,6 @@ variable "create_deployment_pipeline" {
   type        = bool
 }
 
-variable "ecr_custom_lifecycle_policy" {
-  default     = null
-  description = "JSON policy for the ecr registry used in aws_ecr_lifecycle_policy."
-  type        = string
-}
-
 variable "deployment_maximum_percent" {
   description = "Upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment. Not valid when using the `DAEMON` scheduling strategy."
   default     = 200
@@ -170,11 +164,18 @@ variable "ecr" {
   }
 }
 
-variable "ecr_enable_default_lifecycle_policy" {
+variable "ecr_custom_lifecycle_policy" {
   default     = null
-  description = "Default JSON policy for the ecr registry used in aws_ecr_lifecycle_policy. Expires all images except for the last 30."
+  description = "JSON formatted ECR lifecycle policy used for this repository (disabled the default lifecycle policy), see https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters for details."
+  type        = string
+}
+
+variable "ecr_enable_default_lifecycle_policy" {
+  default     = true
+  description = "Enables an ECR lifecycle policy for this repository which expires all images except for the last 30."
   type        = bool
 }
+
 
 variable "force_new_deployment" {
   default     = false


### PR DESCRIPTION
## what 

Enable default ECR lifecycle policy (which can be disabled). In addition, disabled default policy if custom JSON is specified, see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy

## why

```
╷
│ Error: Null condition
│ 
│   on .terraform/modules/service/modules/ecr/main.tf line 19, in resource "aws_ecr_lifecycle_policy" "default_lifecycle_policy":
│   19:   count      = var.enable_default_lifecycle_policy ? 1 : 0
│     ├────────────────
│     │ var.enable_default_lifecycle_policy is null
│ 
│ The condition value is null. Conditions must either be true or false.
```

and:

> Only one aws_ecr_lifecycle_policy resource can be used with the same ECR repository. To apply multiple rules, they must be combined in the policy JSON.

