### PR TITLE
refactor(fluentbit): default to enabled Aws_Auth

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,11 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.77.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
         args:
           - --init-args=-backend=false
-          - --init-args=-lockfile=readonly
       - id: terraform_tflint
       - id: terraform_tfsec
         args:

--- a/README.md
+++ b/README.md
@@ -274,8 +274,10 @@ for example.
 | <a name="output_container_definitions"></a> [container\_definitions](#output\_container\_definitions) | Container definitions used by this service including all sidecars. |
 | <a name="output_ecr_repository_arn"></a> [ecr\_repository\_arn](#output\_ecr\_repository\_arn) | Full ARN of the ECR repository. |
 | <a name="output_ecr_repository_url"></a> [ecr\_repository\_url](#output\_ecr\_repository\_url) | URL of the ECR repository. |
-| <a name="output_ecs_task_exec_role_arn"></a> [ecs\_task\_exec\_role\_arn](#output\_ecs\_task\_exec\_role\_arn) | The ARN of the ECS task role created for this service. |
-| <a name="output_ecs_task_exec_role_name"></a> [ecs\_task\_exec\_role\_name](#output\_ecs\_task\_exec\_role\_name) | The name of the ECS task role created for this service. |
-| <a name="output_ecs_task_exec_role_unique_id"></a> [ecs\_task\_exec\_role\_unique\_id](#output\_ecs\_task\_exec\_role\_unique\_id) | The unique id of the ECS task role created for this service. |
-| <a name="output_target_group_arns"></a> [target\_group\_arns](#output\_target\_group\_arns) | ARNs of the created target groups. |
+| <a name="output_task_execution_role_arn"></a> [task\_execution\_role\_arn](#output\_task\_execution\_role\_arn) | ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
+| <a name="output_task_execution_role_name"></a> [task\_execution\_role\_name](#output\_task\_execution\_role\_name) | Friendly name of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
+| <a name="output_task_execution_role_unique_id"></a> [task\_execution\_role\_unique\_id](#output\_task\_execution\_role\_unique\_id) | Stable and unique string identifying the IAM role that the Amazon ECS container agent and the Docker daemon can assume. |
+| <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. |
+| <a name="output_task_role_name"></a> [task\_role\_name](#output\_task\_role\_name) | Friendly name of IAM role that allows your Amazon ECS container task to make calls to other AWS services. |
+| <a name="output_task_role_unique_id"></a> [task\_role\_unique\_id](#output\_task\_role\_unique\_id) | Stable and unique string identifying the IAM role that allows your Amazon ECS container task to make calls to other AWS services. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/container_definition.tf
+++ b/container_definition.tf
@@ -13,15 +13,16 @@ locals {
     logConfiguration = var.firelens.enabled && var.firelens.opensearch_host != "" ? {
       logDriver = "awsfirelens",
       options = {
-        Aws_Auth        = "Off"
-        Aws_Region      = data.aws_region.current.name
-        Host            = var.firelens.opensearch_host
-        Logstash_Format = "true"
-        Logstash_Prefix = "${var.service_name}-app"
-        Name            = "opensearch"
-        Port            = "443"
-        tls             = "On"
-        Trace_Output    = "Off"
+        Aws_Auth           = "On"
+        Aws_Region         = data.aws_region.current.name
+        Host               = var.firelens.opensearch_host
+        Logstash_Format    = "true"
+        Logstash_Prefix    = "${var.service_name}-app"
+        Name               = "opensearch"
+        Port               = "443"
+        Suppress_Type_Name = "On"
+        tls                = "On"
+        Trace_Output       = "Off"
       }
       } : (var.cloudwatch_logs.enabled ? {
         logDriver = "awslogs"

--- a/envoy.tf
+++ b/envoy.tf
@@ -38,15 +38,16 @@ locals {
     logConfiguration = var.firelens.enabled && var.firelens.opensearch_host != "" ? {
       logDriver = "awsfirelens",
       options = {
-        Aws_Auth        = "Off"
-        Aws_Region      = data.aws_region.current.name
-        Host            = var.firelens.opensearch_host
-        Logstash_Format = "true"
-        Logstash_Prefix = "${var.service_name}-envoy"
-        Name            = "opensearch"
-        Port            = "443"
-        tls             = "On"
-        Trace_Output    = "Off"
+        Aws_Auth           = "On"
+        Aws_Region         = data.aws_region.current.name
+        Host               = var.firelens.opensearch_host
+        Logstash_Format    = "true"
+        Logstash_Prefix    = "${var.service_name}-envoy"
+        Name               = "opensearch"
+        Port               = "443"
+        Suppress_Type_Name = "On"
+        tls                = "On"
+        Trace_Output       = "Off"
       }
       } : (var.cloudwatch_logs.enabled ? {
         logDriver = "awslogs"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "autoscaling_target" {
+  description = "ECS auto scaling targets if auto scaling enabled."
+  value       = try(aws_appautoscaling_target.ecs[0], null)
+}
+
 output "cloudwatch_log_group" {
   description = "Name of the CloudWatch log group for container logs."
   value       = try(aws_cloudwatch_log_group.containers[0].name, "")
@@ -19,30 +24,34 @@ output "ecr_repository_url" {
   value       = join("", module.ecr[*].repository_url)
 }
 
-output "ecs_task_exec_role_arn" {
-  description = "The ARN of the ECS task role created for this service."
-  value       = try(aws_iam_role.ecs_task_role[0].arn, "")
+output "task_role_arn" {
+  description = "ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services."
+  value       = try(aws_iam_role.ecs_task_role[0].arn, var.task_role_arn)
 }
 
-output "ecs_task_exec_role_name" {
-  description = "The name of the ECS task role created for this service."
+output "task_role_name" {
+  description = "Friendly name of IAM role that allows your Amazon ECS container task to make calls to other AWS services."
   value       = try(aws_iam_role.ecs_task_role[0].name, "")
 }
 
-output "ecs_task_exec_role_unique_id" {
-  description = "The unique id of the ECS task role created for this service."
+output "task_role_unique_id" {
+  description = "Stable and unique string identifying the IAM role that allows your Amazon ECS container task to make calls to other AWS services."
   value       = try(aws_iam_role.ecs_task_role[0].unique_id, "")
 }
 
-output "autoscaling_target" {
-  description = "ECS auto scaling targets if auto scaling enabled."
-  value       = try(aws_appautoscaling_target.ecs[0], null)
+output "task_execution_role_arn" {
+  description = "ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  value       = try(aws_iam_role.task_execution_role[0].arn, var.task_execution_role_arn)
 }
 
-// TODO: remove this intermediate output
-output "target_group_arns" {
-  description = "ARNs of the created target groups."
-  value       = aws_alb_target_group.main[*].arn
+output "task_execution_role_name" {
+  description = "Friendly name of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  value       = try(aws_iam_role.task_execution_role[0].name, "")
+}
+
+output "task_execution_role_unique_id" {
+  description = "Stable and unique string identifying the IAM role that the Amazon ECS container agent and the Docker daemon can assume."
+  value       = try(aws_iam_role.task_execution_role[0].unique_id, "")
 }
 
 // TODO: this output should not start with "aws"


### PR DESCRIPTION
## what

- default to enabled `Aws_Auth` and enabled `Suppress_Type_Name` in Opensearch log configurations
- created distinct outputs for task role and task execution role

## why

- default to secure communication with Opensearch domains using fine-grained access controll and/or access policies
- default to Opensearch domains without deprecated mapping type (see [Fluentbit docs](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch))
