### PR TITLE
feat: support `ALBRequestCountPerTarget` scaling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -275,6 +275,7 @@ resource "aws_appautoscaling_policy" "ecs" {
 
     predefined_metric_specification {
       predefined_metric_type = lookup(var.appautoscaling_settings, "predefined_metric_type", "ECSServiceAverageCPUUtilization")
+      resource_label         = lookup(var.appautoscaling_settings, "resource_label")
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,8 +54,12 @@ output "task_execution_role_unique_id" {
   value       = try(aws_iam_role.task_execution_role[0].unique_id, "")
 }
 
-// TODO: this output should not start with "aws"
-output "aws_alb_target_group_arns" {
+output "alb_target_group_arns" {
   description = "ARNs of the created target groups."
   value       = aws_alb_target_group.main[*].arn
+}
+
+output "alb_target_group_arn_suffixes" {
+  description = "ARN suffixes of the created target groups."
+  value       = aws_alb_target_group.main[*].arn_suffix
 }


### PR DESCRIPTION
To be used in conjunction with [AppAutoscaling](https://docs.aws.amazon.com/autoscaling/plans/APIReference/API_PredefinedScalingMetricSpecification.html) with `ALBRequestCountPerTarget`