### PR TITLE
chore(otel): update collector version

### DIFF
--- a/otel.tf
+++ b/otel.tf
@@ -2,7 +2,7 @@ locals {
   // optional AWS Distro for OpenTelemetry container
   otel_container_defaults = {
     essential              = false
-    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.29.0"
+    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.36.0"
     name                   = "otel"
     readonlyRootFilesystem = false
     mountPoints            = []


### PR DESCRIPTION
> You are receiving this message because you are using the AWS Distro for OpenTelemetry (ADOT) collector to send metrics to Amazon Managed Service for Prometheus.
> In order to remain fully compatible with the upstream OpenTelemetry collector, starting with version v0.35.0 [1] of the ADOT collector there are changes in the naming of metrics exported by the Prometheus remote write exporter. Suffixes may be added to metrics so that they follow the best practices for naming metrics [2]. If you don’t take any action this might result in existing dashboards or alarms referencing stale metrics.
> We ask you to please review our guide [3] to understand the changes being made and to determine what the behaviour is that you want to use for this component (add suffixes or don't add suffixes).