### PR TITLE
fix: autoscaling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -253,7 +253,7 @@ resource "aws_appautoscaling_target" "ecs" {
 
   max_capacity       = lookup(var.appautoscaling_settings, "max_capacity", var.desired_count)
   min_capacity       = lookup(var.appautoscaling_settings, "min_capacity", var.desired_count)
-  resource_id        = "service/${var.cluster_id}/${aws_ecs_service.this.name}"
+  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.this.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,10 @@ variable "cluster_id" {
   type        = string
 }
 
+variable "cluster_name" {
+  description = "The ECS cluster name"
+}
+
 variable "container_port" {
   description = "The port used by the app within the container."
   type        = number


### PR DESCRIPTION
The autoscaling policy was not being applied to the ECS service because the Cluster ID is an ARN.

This change results in the following fix:

```
 ~ resource_id        = "service/arn:aws:ecs:ap-southeast-1:99999995008:cluster/my_cluster/my-portal" -> "service/my_cluster/my-portal" # forces replacement
```
