### PR TITLE
chore: respect the upcoming changes in ECS Tagging

### DIFF
--- a/modules/deployment/iam_code_pipeline.tf
+++ b/modules/deployment/iam_code_pipeline.tf
@@ -73,7 +73,8 @@ data "aws_iam_policy_document" "code_pipepline_permissions" {
     actions = [
       # cloudtrail reports that codepipeline actually requires access to `*`
       "ecs:DescribeTaskDefinition",
-      "ecs:RegisterTaskDefinition"
+      "ecs:RegisterTaskDefinition",
+      "ecs:TagResource"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
Starting August 2024 you'll need the explicit `ecs:TagResource` permission in conjunction with certain ECS related API calls, on of them being `RegisterTaskDefinition`

See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#tag-resources-setting

the [documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelasticcontainerservice.html#amazonelasticcontainerservice-task-definition) states that we could allow to restrict this to a certain task-definition ARN/pattern, but we do not have access to this, I fear.