### PR TITLE
fix(alb): complete example can be applied without errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,8 @@ for example.
 | <a name="output_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#output\_cloudwatch\_log\_group) | Name of the CloudWatch log group for container logs. |
 | <a name="output_container_definitions"></a> [container\_definitions](#output\_container\_definitions) | Container definitions used by this service including all sidecars. |
 | <a name="output_ecr_repository_arn"></a> [ecr\_repository\_arn](#output\_ecr\_repository\_arn) | Full ARN of the ECR repository. |
-| <a name="output_ecr_repository_url"></a> [ecr\_repository\_url](#output\_ecr\_repository\_url) | URL of the ECR repository. |
+| <a name="output_ecr_repository_id"></a> [ecr\_repository\_id](#output\_ecr\_repository\_id) | The registry ID where the repository was created. |
+| <a name="output_ecr_repository_url"></a> [ecr\_repository\_url](#output\_ecr\_repository\_url) | The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`) |
 | <a name="output_task_execution_role_arn"></a> [task\_execution\_role\_arn](#output\_task\_execution\_role\_arn) | ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
 | <a name="output_task_execution_role_name"></a> [task\_execution\_role\_name](#output\_task\_execution\_role\_name) | Friendly name of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
 | <a name="output_task_execution_role_unique_id"></a> [task\_execution\_role\_unique\_id](#output\_task\_execution\_role\_unique\_id) | Stable and unique string identifying the IAM role that the Amazon ECS container agent and the Docker daemon can assume. |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -34,22 +34,20 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb_security_group_public"></a> [alb\_security\_group\_public](#module\_alb\_security\_group\_public) | registry.terraform.io/terraform-aws-modules/security-group/aws | >= 4.17 |
+| <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | ~> 9.0 |
 | <a name="module_service"></a> [service](#module\_service) | ../../ | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | registry.terraform.io/terraform-aws-modules/vpc/aws | >= 4.0 |
-| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | registry.terraform.io/terraform-aws-modules/vpc/aws//modules/vpc-endpoints | >= 4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
-| [aws_lb.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
-| [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_security_group.egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [null_resource.initial_image](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -17,8 +17,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4 |
 
@@ -26,7 +26,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.2 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.4 |
 
@@ -59,5 +59,5 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | n/a |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_availability_zones" "available" {
   state = "available"
 }

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -3,8 +3,3 @@ data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {
   state = "available"
 }
-
-data "aws_security_group" "default" {
-  name   = "default"
-  vpc_id = module.vpc.vpc_id
-}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -77,7 +77,8 @@ module "alb" {
 }
 
 module "service" {
-  source = "../../"
+  source     = "../../"
+  depends_on = [module.vpc]
 
   cpu                           = 256
   cpu_architecture              = "ARM64"
@@ -143,6 +144,9 @@ resource "aws_security_group" "egress_all" {
   description = "Allow all outbound traffic"
   vpc_id      = module.vpc.vpc_id
 
+  # make sure to secure traffic in production environments
+  # see https://avd.aquasec.com/misconfig/aws/ec2/avd-aws-0104/#Terraform
+  #trivy:ignore:AVD-AWS-0104
   egress {
     from_port        = 0
     to_port          = 0

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -158,7 +158,7 @@ resource "aws_security_group" "egress_all" {
 
 resource "null_resource" "initial_image" {
   provisioner "local-exec" {
-    command = "aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${module.service.ecr_repository_url}"
+    command = "aws ecr get-login-password --region ${var.region} | docker login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com"
   }
 
   provisioner "local-exec" {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,3 +1,3 @@
 output "alb_dns_name" {
-  value = aws_lb.public.dns_name
+  value = module.alb.dns_name
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,3 +1,3 @@
-output "alb_dns_name" {
-  value = module.alb.dns_name
+output "endpoint" {
+  value = "http://${module.alb.dns_name}/"
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 5.32"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/fixtures/context/Dockerfile
+++ b/examples/fixtures/context/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.9-alpine
+FROM python:3.12-alpine
 
 ADD index.html index.html
 ADD server.py server.py
 
-USER app
+#USER app
 EXPOSE 8000
 
 ENTRYPOINT ["python3", "server.py"]

--- a/examples/fixtures/context/Dockerfile
+++ b/examples/fixtures/context/Dockerfile
@@ -1,9 +1,15 @@
 FROM python:3.12-alpine
 
-ADD index.html index.html
-ADD server.py server.py
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /home/app
 
-#USER app
+ADD index.html /home/app/index.html
+ADD server.py /home/app/server.py
+
+RUN chown -R app:app /home/app
+
+USER app
+
 EXPOSE 8000
 
 ENTRYPOINT ["python3", "server.py"]

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 data "aws_lb" "public" {
-  for_each = var.create_ingress_security_group ? { for idx, target in var.target_groups : lookup(target, "load_balancer_arn", "") => lookup(target, "load_balancer_arn", "") } : {}
+  for_each = var.create_ingress_security_group ? { for idx, target in var.target_groups : idx => lookup(target, "load_balancer_arn", "") } : {}
   arn      = each.value
 }
 
 locals {
   ingress_targets = flatten(
     [
-      for target in var.target_groups : flatten(
+      for idx, target in var.target_groups : flatten(
         [
           [
             {
@@ -14,7 +14,7 @@ locals {
               from_port                = lookup(target, "backend_port", null)
               to_port                  = lookup(target, "backend_port", null)
               protocol                 = "tcp"
-              source_security_group_id = tolist(data.aws_lb.public[lookup(target, "load_balancer_arn", null)].security_groups)[0]
+              source_security_group_id = tolist(data.aws_lb.public[idx].security_groups)[0]
               prefix                   = "backend_port"
             }
           ],
@@ -27,7 +27,7 @@ locals {
               from_port                = target["health_check"]["port"]
               to_port                  = target["health_check"]["port"]
               protocol                 = "tcp"
-              source_security_group_id = tolist(data.aws_lb.public[lookup(target, "load_balancer_arn", null)].security_groups)[0]
+              source_security_group_id = tolist(data.aws_lb.public[idx].security_groups)[0]
               prefix                   = "health_check_port"
             }
           ] : []

--- a/modules/deployment/iam_code_pipeline.tf
+++ b/modules/deployment/iam_code_pipeline.tf
@@ -69,9 +69,10 @@ data "aws_iam_policy_document" "code_pipepline_permissions" {
     resources = [aws_codebuild_project.this.arn]
   }
 
+  # cloudtrail reports that codepipeline actually requires access to `*`
+  #trivy:ignore:AVD-AWS-0057
   statement {
     actions = [
-      # cloudtrail reports that codepipeline actually requires access to `*`
       "ecs:DescribeTaskDefinition",
       "ecs:RegisterTaskDefinition",
       "ecs:TagResource"

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,8 +19,13 @@ output "ecr_repository_arn" {
   value       = join("", module.ecr[*].arn)
 }
 
+output "ecr_repository_id" {
+  description = "The registry ID where the repository was created."
+  value       = join("", module.ecr[*].registry_id)
+}
+
 output "ecr_repository_url" {
-  description = "URL of the ECR repository."
+  description = "The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`)"
   value       = join("", module.ecr[*].repository_url)
 }
 


### PR DESCRIPTION
## what

- Enhances complete example so it can be applied without errors
- fixes security group code, so new services can be create with `create_ingress_security_group = true`, see https://github.com/stroeer/terraform-aws-ecs-fargate/issues/149

> [!CAUTION]  
> When applying this code, the existing ingress security group will be replaced, make sure this is acceptable in your environment
