### PR TITLE
fix: support awslogs-group from provided name

### DIFF
--- a/fluentbit.tf
+++ b/fluentbit.tf
@@ -50,7 +50,7 @@ locals {
     logConfiguration = var.cloudwatch_logs.enabled ? {
       logDriver = "awslogs"
       options = {
-        awslogs-group         = aws_cloudwatch_log_group.containers[0].name
+        awslogs-group         = var.cloudwatch_logs.name == "" ? aws_cloudwatch_log_group.containers[0].name : var.cloudwatch_logs.name
         awslogs-region        = data.aws_region.current.name
         awslogs-stream-prefix = "fluentbit"
         mode                  = "non-blocking"

--- a/otel.tf
+++ b/otel.tf
@@ -15,7 +15,7 @@ locals {
     logConfiguration = var.cloudwatch_logs.enabled ? {
       logDriver = "awslogs"
       options = {
-        awslogs-group         = aws_cloudwatch_log_group.containers[0].name
+        awslogs-group         = var.cloudwatch_logs.name == "" ? aws_cloudwatch_log_group.containers[0].name : var.cloudwatch_logs.name
         awslogs-region        = data.aws_region.current.name
         awslogs-stream-prefix = "otel"
         mode                  = "non-blocking"


### PR DESCRIPTION
bugfix: get awslogs-group either from `aws_cloudwatch_log_group.containers` or use provided `var.cloudwatch_logs.name`

tries to fix: https://github.com/stroeer/paper/actions/runs/10056993152/job/27797245512#step:5:105