### PR TITLE
feat(multi-region): configurable aws_region for firelense

### DIFF
--- a/container_definition.tf
+++ b/container_definition.tf
@@ -16,7 +16,7 @@ locals {
       logDriver = "awsfirelens",
       options = {
         Aws_Auth           = "On"
-        Aws_Region         = data.aws_region.current.name
+        Aws_Region         = null != var.firelens.aws_region ? var.firelens.aws_region : data.aws_region.current.name
         Host               = var.firelens.opensearch_host
         Logstash_Format    = "true"
         Logstash_Prefix    = "${var.service_name}-app"

--- a/envoy.tf
+++ b/envoy.tf
@@ -41,7 +41,7 @@ locals {
       logDriver = "awsfirelens",
       options = {
         Aws_Auth           = "On"
-        Aws_Region         = data.aws_region.current.name
+        Aws_Region         = null != var.firelens.aws_region ? var.firelens.aws_region : data.aws_region.current.name
         Host               = var.firelens.opensearch_host
         Logstash_Format    = "true"
         Logstash_Prefix    = "${var.service_name}-envoy"

--- a/variables.tf
+++ b/variables.tf
@@ -332,6 +332,7 @@ variable "firelens" {
     init_config_files            = optional(list(string), [])
     log_level                    = optional(string, "info")
     opensearch_host              = optional(string, "")
+    aws_region                   = optional(string)
   })
 }
 


### PR DESCRIPTION
Allow changing the `aws_region` used by firelense to sign off requests in case the stack was deployed in a region that does match OpenSearch's region.