### PR TITLE
feat: forbid nullable codebuild variables, to use default variables on null

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -33,6 +33,6 @@ jobs:
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
-            starts with an uppercase character.
+            doesn't starts with an uppercase character.
           wip: true
           validateSingleCommit: false

--- a/variables.tf
+++ b/variables.tf
@@ -184,18 +184,21 @@ variable "code_build_environment_compute_type" {
   description = "Information about the compute resources the CodeBuild stage of the deployment pipeline will use."
   default     = "BUILD_LAMBDA_1GB"
   type        = string
+  nullable    = false
 }
 
 variable "code_build_environment_image" {
   description = "Docker image to use for the CodeBuild stage of the deployment pipeline. The image needs to include python."
   default     = "aws/codebuild/amazonlinux-aarch64-lambda-standard:python3.12"
   type        = string
+  nullable    = false
 }
 
 variable "code_build_environment_type" {
   description = "Type of build environment for the CodeBuild stage of the deployment pipeline."
   default     = "ARM_LAMBDA_CONTAINER"
   type        = string
+  nullable    = false
 }
 
 variable "code_build_role_name" {


### PR DESCRIPTION
Currently, you can use "null" for the value of the codebuild-variables. If you do that, you will receive an error from the underlying module.

In order to fix this, I've set the variables to `nullable=false` which should protect you from this error.

If you paste null, then the default value will be used (source: https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values)
