### PR TITLE
chore: dep update otel to 0.42

### DIFF
--- a/otel.tf
+++ b/otel.tf
@@ -2,7 +2,7 @@ locals {
   // optional AWS Distro for OpenTelemetry container
   otel_container_defaults = {
     essential              = false
-    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.36.0"
+    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.42.0"
     name                   = "otel"
     readonlyRootFilesystem = false
     mountPoints            = []


### PR DESCRIPTION
Summarized breaking changes since 0.36.0 https://github.com/aws-observability/aws-otel-collector/releases

- The memory_ballast extension was removed upstream and ADOT Collector in favor of the GOMEMLIMIT environment variable, See the [Go documentation](https://pkg.go.dev/runtime#hdr-Environment_Variables) for more information about GOMEMLIMIT's usage.
- The logging exporter has been removed upstream in favor of the debug exporter. This release removes the logging exporter. See https://github.com/open-telemetry/opentelemetry-collector/issues/11337 to migrate to the debug exporter.
- Note: Expansion of BASH-style environment variables, such as $FOO, is no longer be supported. Use ${FOO} or ${env:FOO} instead.
