### PR TITLE
chore(gh): pinned versions of unverified GitHub actions

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -12,7 +12,7 @@ jobs:
     name: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # 5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -56,7 +56,7 @@ jobs:
 
           cat ./trivy.yaml
 
-      - uses: aquasecurity/trivy-action@0.26.0
+      - uses: aquasecurity/trivy-action@0.30.0
         with:
           scan-type: 'config'
           hide-progress: false


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to use specific versions of actions for better stability and security.

Updates to GitHub Actions workflows:

* [`.github/workflows/pr-title.yaml`](diffhunk://#diff-872a5dc5cb41e92ee26fda3012879c7f6b8dcdedd57822c134fbf887886ca4eeL15-R15): Updated the `amannn/action-semantic-pull-request` action to use a specific commit hash `0723387faaf9b38adef4775cd42cfd5155ed6017` corresponding to version 5.5.3.
* [`.github/workflows/static-analysis.yaml`](diffhunk://#diff-5d68f6ca696b457d708e1895ce1dcab8820f9d6d9357b3876176cbcdd9808b98L30-R30): Updated the `terraform-linters/setup-tflint` action to use a specific commit hash `90f302c255ef959cbfb4bd10581afecdb7ece3e6` corresponding to version 4.1.1.
* [`.github/workflows/static-analysis.yaml`](diffhunk://#diff-5d68f6ca696b457d708e1895ce1dcab8820f9d6d9357b3876176cbcdd9808b98L59-R59): Updated the `aquasecurity/trivy-action` action from version 0.26.0 to 0.30.0.