### PR TITLE
chore(envoy): bumped default envoy to v1.29.12.1-prod

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.0
+    rev: v1.99.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -4,6 +4,6 @@ config {
 
 plugin "aws" {
   enabled = true
-  version = "0.33.0"
+  version = "0.40.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/envoy.tf
+++ b/envoy.tf
@@ -3,7 +3,7 @@ locals {
   envoy_container_defaults = {
     dependsOn              = var.firelens.enabled ? [{ containerName = var.firelens.container_name, condition = "HEALTHY" }] : []
     name                   = var.app_mesh.container_name
-    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/appmesh/aws-appmesh-envoy:v1.27.3.0-prod"
+    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/appmesh/aws-appmesh-envoy:v1.29.12.1-prod"
     essential              = true
     mountPoints            = []
     portMappings           = []


### PR DESCRIPTION
This pull request includes updates to dependencies and configurations for Terraform and TFLint, as well as an update to the Envoy container image version in the `envoy.tf` file. These changes ensure compatibility with newer versions and improve functionality.

### Envoy Configuration Update:
* [`envoy.tf`](diffhunk://#diff-ded462a2e0a4c98d25a7d3ed8e7f7206713df6c525ecaa2785b8d9b0cabefb94L6-R6): Updated the Envoy container image version from `v1.27.3.0-prod` to `v1.29.12.1-prod` to use the latest version.

### Dependency Updates:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R3): Updated `pre-commit-terraform` hook version from `v1.99.0` to `v1.99.1`.
* [`.tflint.hcl`](diffhunk://#diff-c82c2fd3fe5d1315facdf6794e11d51e0bf10783e6ef34a270996a62bccf605dL7-R7): Updated the `aws` plugin version for TFLint from `0.33.0` to `0.40.0`.