### PR TITLE
fix: local ingress targets are nonsensitive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "aws_lb" "public" {
 }
 
 locals {
-  ingress_targets = flatten(
+  ingress_targets = nonsensitive(flatten(
     [
       for idx, target in var.target_groups : flatten(
         [
@@ -34,7 +34,7 @@ locals {
         ]
       ) if var.create_ingress_security_group
     ]
-  )
+  ))
 
   additional_sidecars   = [for s in var.additional_container_definitions : jsonencode(s)]
   container_definitions = "[${join(",", concat(compact([local.app_container, local.envoy_container, local.fluentbit_container, local.otel_container])), compact(local.additional_sidecars))}]"


### PR DESCRIPTION
```
Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Error: Invalid for_each argument
│ 
│   on .terraform/modules/prod.service/main.tf line 68, in resource "aws_security_group_rule" "trusted_egress_attachment":
│   68:   for_each                 = { for route in local.ingress_targets : "${route["prefix"]}-${route["protocol"]}-${route["from_port"]}-${route["to_port"]}" => route }
│     ├────────────────
│     │ local.ingress_targets has a sensitive value
│ 
│ Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.
╵
```