### PR TITLE
feat: enabled gzip compression for OpenSearch logs

### DIFF
--- a/container_definition.tf
+++ b/container_definition.tf
@@ -17,6 +17,7 @@ locals {
       options = {
         Aws_Auth           = "On"
         Aws_Region         = null != var.firelens.aws_region ? var.firelens.aws_region : data.aws_region.current.name
+        Compress           = "gzip"
         Host               = var.firelens.opensearch_host
         Logstash_Format    = "true"
         Logstash_Prefix    = "${var.service_name}-app"

--- a/envoy.tf
+++ b/envoy.tf
@@ -42,6 +42,7 @@ locals {
       options = {
         Aws_Auth           = "On"
         Aws_Region         = null != var.firelens.aws_region ? var.firelens.aws_region : data.aws_region.current.name
+        Compress           = "gzip"
         Host               = var.firelens.opensearch_host
         Logstash_Format    = "true"
         Logstash_Prefix    = "${var.service_name}-envoy"


### PR DESCRIPTION
This pull request adds compression settings to the logging configuration for OpenSearch in two Terraform files: `container_definition.tf` and `envoy.tf`. 

AWS [recommends](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/bp.html#bp-perf) to enable ´gzip´ compression for bulk requests for performance reasons, so we use it by default.

### Logging Configuration Updates:

* [`container_definition.tf`](diffhunk://#diff-06e91c984f40de4069ecda2a2b4438e8a586e2a943004baa1633a4d6c61c4d6cR20): Added the `Compress` option set to `"gzip"` in the logging configuration for application logs.
* [`envoy.tf`](diffhunk://#diff-ded462a2e0a4c98d25a7d3ed8e7f7206713df6c525ecaa2785b8d9b0cabefb94R45): Added the `Compress` option set to `"gzip"` in the logging configuration for Envoy logs.