### PR TITLE
fix(iam): dynamic SSM permissions for new services

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,19 +185,17 @@ for example.
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_policy.acm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cloudwatch_logs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.enable_execute_command](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.fluent_bit_config_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.otel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.ecs_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ecs_task_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.execute_command](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.logs_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.acm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.appmesh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_logs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.enable_execute_command](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.fluent_bit_config_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.otel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_service_discovery_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
@@ -211,9 +209,8 @@ for example.
 | [aws_iam_policy_document.ecs_task_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.enable_execute_command](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fluent_bit_config_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.logs_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.otel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -44,6 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_security_group.egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_ssm_parameter.secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [null_resource.initial_image](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -44,7 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_security_group.egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_ssm_parameter.secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [null_resource.initial_image](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -101,6 +101,9 @@ module "service" {
   security_groups               = [aws_security_group.egress_all.id]
   vpc_id                        = module.vpc.vpc_id
 
+  // (optionally) enable ECS Exec, see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  enable_execute_command = true
+
   // configure autoscaling for this service
   appautoscaling_settings = {
     max_capacity           = 4

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -76,6 +76,12 @@ module "alb" {
   }
 }
 
+resource "aws_ssm_parameter" "secret" {
+  name  = "FOO_SECRET"
+  type  = "SecureString"
+  value = "CHANGE_ME"
+}
+
 module "service" {
   source     = "../../"
   depends_on = [module.vpc]
@@ -106,6 +112,10 @@ module "service" {
   // overwrite the default container definition or add further task definition parameters
   container_definition_overwrites = {
     readonlyRootFilesystem = false
+
+    secrets = [
+      { "name" : aws_ssm_parameter.secret.name, "valueFrom" : aws_ssm_parameter.secret.arn }
+    ]
   }
 
   // add listener rules that determine how the load balancer routes requests to its registered targets.

--- a/iam.tf
+++ b/iam.tf
@@ -101,29 +101,6 @@ data "aws_iam_policy_document" "logs_ssm" {
   }
 }
 
-data "aws_iam_policy_document" "enable_execute_command" {
-  count = var.enable_execute_command && var.task_role_arn == "" ? 1 : 0
-
-  statement {
-    actions = [
-      "ssmmessages:CreateControlChannel",
-      "ssmmessages:CreateDataChannel",
-      "ssmmessages:OpenControlChannel",
-      "ssmmessages:OpenDataChannel",
-    ]
-
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_role_policy" "execute_command" {
-  count = var.enable_execute_command ? 1 : 0
-
-  name   = "execute-command-policy"
-  policy = data.aws_iam_policy_document.enable_execute_command[0].json
-  role   = aws_iam_role.task_execution_role[0].id
-}
-
 data "aws_iam_policy_document" "task_execution_role" {
   count = var.task_execution_role_arn == "" ? 1 : 0
 
@@ -166,4 +143,27 @@ data "aws_iam_policy_document" "ecs_task_assume_role_policy" {
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
+}
+
+data "aws_iam_policy_document" "enable_execute_command" {
+  count = var.enable_execute_command && var.task_role_arn == "" ? 1 : 0
+
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "execute_command" {
+  count = var.enable_execute_command && var.task_role_arn == "" ? 1 : 0
+
+  name   = "execute-command-policy"
+  policy = data.aws_iam_policy_document.enable_execute_command[0].json
+  role   = aws_iam_role.ecs_task_role[0].id
 }

--- a/iam.tf
+++ b/iam.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role_policy" "ecr" {
   count = var.task_execution_role_arn == "" ? 1 : 0
 
   name   = "ecr-policy"
-  role   = aws_iam_role.task_execution_role[0].id
+  role   = aws_iam_role.task_execution_role[count.index].id
   policy = data.aws_iam_policy_document.ecr.json
 }
 
@@ -73,7 +73,7 @@ resource "aws_iam_role_policy" "logs_ssm" {
   count = var.task_execution_role_arn == "" ? 1 : 0
 
   name   = "logs-and-ssm-policy"
-  role   = aws_iam_role.task_execution_role[0].id
+  role   = aws_iam_role.task_execution_role[count.index].id
   policy = data.aws_iam_policy_document.logs_ssm.json
 }
 
@@ -164,6 +164,6 @@ resource "aws_iam_role_policy" "execute_command" {
   count = var.enable_execute_command && var.task_role_arn == "" ? 1 : 0
 
   name   = "execute-command-policy"
-  policy = data.aws_iam_policy_document.enable_execute_command[0].json
-  role   = aws_iam_role.ecs_task_role[0].id
+  policy = data.aws_iam_policy_document.enable_execute_command[count.index].json
+  role   = aws_iam_role.ecs_task_role[count.index].id
 }

--- a/iam.tf
+++ b/iam.tf
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "logs_ssm" {
   }
 
   dynamic "statement" {
-    for_each = local.ssm_parameters
+    for_each = length(local.ssm_parameters) > 0 ? [true] : []
 
     content {
       actions   = ["ssm:GetParameter*", "ssm:DescribeParameters"]


### PR DESCRIPTION
## what

This PR refactors IAM policy creation to resolve Terraform planning issues for new stacks by consolidating separate SSM and logs policies into a single policy that can be evaluated at plan time. The changes enable dynamic SSM permissions for both main container definitions and additional container definitions while maintaining proper IAM access controls.

- Consolidates separate IAM policies (SSM, logs, execute command) into unified policies to avoid count dependencies on unknown resources
- Enhances the complete example to demonstrate SSM parameter store integration with secrets
- Updates documentation to reflect the new IAM resource structure

## why

terraform plan for new stacks currently fails with

```
Error: Invalid count argument
│ 
│   on ../../iam.tf line 38, in resource "aws_iam_role_policy" "ssm":
│   38:   count = var.task_execution_role_arn == "" && length(local.ssm_parameters) > 0 ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on.
╵
```