### PR TITLE
chore: update FluentBit (3.4.8) and ADOT OTel collector (v0.49.0) sidecars

### DIFF
--- a/fluentbit.tf
+++ b/fluentbit.tf
@@ -12,7 +12,7 @@ locals {
   ]
 
   // default image tag for the FluentBit container
-  image_tag = length(local.init_config_files) > 0 ? "init-3.4.4" : "3.4.4"
+  image_tag = length(local.init_config_files) > 0 ? "init-3.4.8" : "3.4.8"
 
   // additional init config files ARNs from S3 to be used in an IAM policy for the task role
   s3_init_file_arns   = [for conf in local.init_config_files : conf.value if can(regex(local.s3_arn_regex, conf.value))]

--- a/otel.tf
+++ b/otel.tf
@@ -2,7 +2,7 @@ locals {
   // optional AWS Distro for OpenTelemetry container
   otel_container_defaults = {
     essential              = false
-    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.47.0"
+    image                  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.49.0"
     name                   = "otel"
     readonlyRootFilesystem = false
     mountPoints            = []


### PR DESCRIPTION
## What

Bump the two sidecar container images to their latest releases:

| Sidecar | File | Old | New |
|---|---|---|---|
| AWS for Fluent Bit (Firelens) | `fluentbit.tf` | `3.4.4` / `init-3.4.4` | `3.4.8` / `init-3.4.8` |
| ADOT OTel Collector | `otel.tf` | `v0.47.0` | `v0.49.0` |

## Why / relevant changes

**Fluent Bit 3.4.5 → 3.4.8** — no functional change to the log pipeline. The fluent-bit core stays at `v5.0.7` and all AWS plugins are unchanged (cloudwatch `1.9.5`, kinesis `1.10.4`, firehose `1.7.3`). Each patch is just a refreshed Amazon Linux 2023 base image (OS/CVE hygiene).

**ADOT OTel Collector v0.47.0 → v0.49.0**
- Upstream OpenTelemetry Collector + Contrib bumped to `v0.156.0` (was ~v0.151.0), Go toolchain to `1.26.4`.
- **Behaviour change worth noting:** the `eks` resourcedetection detector was dropped for Fargate Container Insights ([#3221](https://github.com/aws-observability/aws-otel-collector/pull/3221)) — expected, since these tasks run on ECS/Fargate, not EKS.

## Risk

Low. Image-tag-only change; no module inputs, defaults, or task-definition structure touched.
